### PR TITLE
Update SAR preview workflow with EAL selection

### DIFF
--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -12,6 +12,7 @@ export interface SarSessionData {
   sarList: any[]
   selectedSarId: number | null
   nextSarId: number
+  selectedEal?: string
   userToken: string
   timestamp: number
 }
@@ -129,11 +130,12 @@ class SessionService {
   /**
    * Save SAR data to session storage
    */
-  saveSarData(sarList: any[], selectedSarId: number | null, nextSarId: number): void {
+  saveSarData(sarList: any[], selectedSarId: number | null, nextSarId: number, selectedEal: string): void {
     const sessionData: SarSessionData = {
       sarList,
       selectedSarId,
       nextSarId,
+      selectedEal,
       userToken: this.userToken,
       timestamp: Date.now()
     }


### PR DESCRIPTION
## Summary
- enable Add SAR interactions on the assurance requirements page and rename the table column to “Assurance Components”
- add an Evaluation Assurance Level selector and rebuild the preview template with the prescribed 5.2 text, grouped table, and class/component breakdown
- persist the chosen EAL level in session storage alongside SAR entries for consistent reloads

## Testing
- npm run build
- Playwright script to upload cc.xml, add an AGD SAR, switch to EAL 2, and capture the preview

------
https://chatgpt.com/codex/tasks/task_e_68ca318e3a14832699e5385b87b7f612