### PR TITLE
feat: enhance SAR preview with template and EAL controls

### DIFF
--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -12,6 +12,7 @@ export interface SarSessionData {
   sarList: any[]
   selectedSarId: number | null
   nextSarId: number
+  ealLevel?: string
   userToken: string
   timestamp: number
 }
@@ -129,11 +130,12 @@ class SessionService {
   /**
    * Save SAR data to session storage
    */
-  saveSarData(sarList: any[], selectedSarId: number | null, nextSarId: number): void {
+  saveSarData(sarList: any[], selectedSarId: number | null, nextSarId: number, ealLevel: string): void {
     const sessionData: SarSessionData = {
       sarList,
       selectedSarId,
       nextSarId,
+      ealLevel,
       userToken: this.userToken,
       timestamp: Date.now()
     }


### PR DESCRIPTION
## Summary
- enable SAR creation from the modal and display formatted class/component rows in the table
- add an Evaluation Assurance Level selector that feeds a new template-driven preview with grouped table and detailed sections
- persist SAR/EAL session data and refresh styling to match the Common Criteria template guidance

## Testing
- npm run build
- Playwright scenario exercising Add SAR and preview rendering

------
https://chatgpt.com/codex/tasks/task_e_68ca318e3a14832699e5385b87b7f612