### PR TITLE
Add DOCX preview workflow for SFR and SAR requirements

### DIFF
--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CCGenTool2</title>
-    <script type="module" crossorigin src="/assets/index-DHneftjZ.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BK6gyiVK.css">
+    <script type="module" crossorigin src="/assets/index-DMxVOd5V.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BlTPU8dW.css">
   </head>
   <body>
     <div id="app"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "1.7.7",
-        "docx-preview": "^0.3.2",
+        "docx-preview": "^0.3.7",
         "pinia": "2.2.4",
         "vue": "3.4.38",
         "vue-router": "4.4.5",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "axios": "1.7.7",
-    "docx-preview": "^0.3.2",
+    "docx-preview": "^0.3.7",
     "pinia": "2.2.4",
     "vue": "3.4.38",
     "vue-router": "4.4.5",

--- a/web/scripts/sfr_preview_screenshot.mjs
+++ b/web/scripts/sfr_preview_screenshot.mjs
@@ -1,0 +1,18 @@
+import { chromium } from 'playwright'
+
+const browser = await chromium.launch()
+const page = await browser.newPage()
+await page.goto('http://127.0.0.1:5173/security/sfr', { waitUntil: 'networkidle' })
+
+await page.getByRole('button', { name: 'Add Custom SFR' }).click()
+await page.getByLabel('SFR Class:', { exact: true }).fill('FFN: Friendly Functionality')
+await page.getByLabel('SFR Components:').fill('FFN_DEF.1 - Demonstration component')
+await page.locator('.modal-content .preview-editor').click()
+await page.keyboard.type('Sample detail for custom SFR preview.')
+await page.getByRole('button', { name: 'Finalize and Add Custom SFR' }).click()
+
+await page.getByRole('button', { name: 'Preview' }).click()
+await page.waitForSelector('.docx-preview-container .docx-rendered-wrapper', { timeout: 20000 })
+await page.waitForTimeout(1000)
+await page.screenshot({ path: '../artifacts/sfr-preview.png', fullPage: true })
+await browser.close()


### PR DESCRIPTION
## Summary
- implement shared HTML-to-DOCX generation on the backend and expose preview/cleanup endpoints for SFR and SAR
- update the SFR and SAR editors to render previews with docx-preview, normalize identifiers to uppercase, and improve SAR duplicate/search handling
- add a reusable Playwright script for capturing SFR preview screenshots

## Testing
- npm run build
- npm run test:e2e


------
https://chatgpt.com/codex/tasks/task_e_68e4bdda182c83268fc95bee907b1f66