### PR TITLE
Implement ST introduction workflow with session persistence

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -21,9 +21,11 @@
 import { onMounted, ref } from 'vue'
 import Sidebar from './components/Sidebar.vue'
 import api from './services/api'
+import { useSessionStore } from './stores/session'
 
 type Health = { status: 'ok'|'degraded'|string, latency_ms: number }
 const health = ref<Health>({ status: 'degraded', latency_ms: 0 })
+const sessionStore = useSessionStore()
 
 async function poll() {
   try{
@@ -35,6 +37,8 @@ async function poll() {
 }
 
 onMounted(() => {
+  sessionStore.ensureUserId()
+  sessionStore.initialize()
   poll()
   setInterval(poll, 5000)
 })

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="rich-text-editor">
+    <div class="toolbar">
+      <button type="button" class="btn" @click="applyFormat('bold')" title="Bold"><strong>B</strong></button>
+      <button type="button" class="btn" @click="applyFormat('italic')" title="Italic"><em>I</em></button>
+      <button type="button" class="btn" @click="applyFormat('underline')" title="Underline"><u>U</u></button>
+      <button type="button" class="btn" @click="applyFormat('unorderedList')" title="Bullet list">• List</button>
+      <button type="button" class="btn" @click="applyFormat('orderedList')" title="Numbered list">1. List</button>
+      <button type="button" class="btn" @click="clearFormatting" title="Clear formatting">Clear</button>
+    </div>
+    <div
+      ref="editor"
+      class="editor"
+      contenteditable="true"
+      :data-placeholder="placeholder"
+      @input="handleInput"
+      @blur="$emit('blur')"
+      @focus="$emit('focus')"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+const props = defineProps<{ modelValue: string; placeholder?: string }>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+  (e: 'blur'): void
+  (e: 'focus'): void
+}>()
+
+const editor = ref<HTMLDivElement | null>(null)
+let updating = false
+
+function setContent(value: string) {
+  if (!editor.value) return
+  updating = true
+  editor.value.innerHTML = value || ''
+  updating = false
+}
+
+onMounted(() => {
+  setContent(props.modelValue)
+})
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (updating) return
+    if (!editor.value) return
+    const current = editor.value.innerHTML
+    if ((value || '') === current) return
+    setContent(value || '')
+  }
+)
+
+function cleanHtml(html: string): string {
+  const trimmed = html.trim()
+  if (!trimmed || trimmed === '<br>' || trimmed === '<div><br></div>') {
+    return ''
+  }
+  return html
+}
+
+function handleInput() {
+  if (!editor.value) return
+  if (updating) return
+  const html = cleanHtml(editor.value.innerHTML)
+  updating = true
+  if (editor.value.innerHTML !== html) {
+    editor.value.innerHTML = html
+  }
+  emit('update:modelValue', html)
+  updating = false
+}
+
+function focusEditor() {
+  editor.value?.focus()
+}
+
+function applyFormat(format: 'bold' | 'italic' | 'underline' | 'unorderedList' | 'orderedList') {
+  if (typeof document === 'undefined') return
+  focusEditor()
+  const commandMap: Record<typeof format, string> = {
+    bold: 'bold',
+    italic: 'italic',
+    underline: 'underline',
+    unorderedList: 'insertUnorderedList',
+    orderedList: 'insertOrderedList',
+  }
+  document.execCommand(commandMap[format], false)
+  handleInput()
+}
+
+function clearFormatting() {
+  if (typeof document === 'undefined') return
+  focusEditor()
+  document.execCommand('removeFormat', false)
+  handleInput()
+}
+</script>
+
+<style scoped>
+.rich-text-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.toolbar .btn {
+  padding: 6px 10px;
+  font-size: 14px;
+}
+
+.editor {
+  min-height: 140px;
+  padding: 12px;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  background: #0b1220;
+  color: var(--text);
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.editor:empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted);
+}
+</style>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,7 +4,22 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/cover" active-class="active">Cover Builder</RouterLink>
+      <div class="accordion">
+        <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
+          <span>ST Introduction</span>
+          <span>{{ stIntroOpen ? '▾' : '▸' }}</span>
+        </div>
+        <div v-if="stIntroOpen" class="accordion-content">
+          <ul class="menu">
+            <li><RouterLink to="/cover" active-class="active">Cover</RouterLink></li>
+            <li><RouterLink to="/st-introduction/reference" active-class="active">ST Reference</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-reference" active-class="active">TOE Reference</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-overview" active-class="active">TOE Overview</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-description" active-class="active">TOE Description</RouterLink></li>
+            <li><RouterLink to="/st-introduction/preview" active-class="active">ST Introduction Preview</RouterLink></li>
+          </ul>
+        </div>
+      </div>
     </li>
     <li>
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
@@ -31,6 +46,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+const stIntroOpen = ref(true)
 const securityOpen = ref(true)
 </script>
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,6 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import Cover from '../views/Cover.vue'
+import StReference from '../views/StReference.vue'
+import ToeReference from '../views/ToeReference.vue'
+import ToeOverview from '../views/ToeOverview.vue'
+import ToeDescription from '../views/ToeDescription.vue'
+import StIntroductionPreview from '../views/StIntroductionPreview.vue'
 import Generator from '../views/Generator.vue'
 import Settings from '../views/Settings.vue'
 import SecurityFunctionalRequirements from '../views/SecurityFunctionalRequirements.vue'
@@ -9,6 +14,11 @@ import SecurityAssuranceRequirements from '../views/SecurityAssuranceRequirement
 const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/cover', name: 'cover', component: Cover },
+  { path: '/st-introduction/reference', name: 'st-reference', component: StReference },
+  { path: '/st-introduction/toe-reference', name: 'toe-reference', component: ToeReference },
+  { path: '/st-introduction/toe-overview', name: 'toe-overview', component: ToeOverview },
+  { path: '/st-introduction/toe-description', name: 'toe-description', component: ToeDescription },
+  { path: '/st-introduction/preview', name: 'st-introduction-preview', component: StIntroductionPreview },
   { path: '/generator', name: 'generator', component: Generator },
   { path: '/settings', name: 'settings', component: Settings },
   { path: '/security/sfr', name: 'security-sfr', component: SecurityFunctionalRequirements },

--- a/web/src/stores/session.ts
+++ b/web/src/stores/session.ts
@@ -1,0 +1,180 @@
+import { defineStore } from 'pinia'
+import { reactive, ref } from 'vue'
+import api from '../services/api'
+
+export type SectionKey = 'cover' | 'stReference' | 'toeReference' | 'toeOverview' | 'toeDescription'
+
+const SECTION_TO_SERVER: Record<SectionKey, string> = {
+  cover: 'cover',
+  stReference: 'st_reference',
+  toeReference: 'toe_reference',
+  toeOverview: 'toe_overview',
+  toeDescription: 'toe_description',
+}
+
+export const useSessionStore = defineStore('session', () => {
+  const storageKey = 'ccgen-user-id'
+  const userId = ref('')
+  const initializing = ref(false)
+  const initialized = ref(false)
+
+  const cover = reactive({
+    fields: {
+      title: '',
+      version: '',
+      revision: '',
+      description: '',
+      manufacturer: '',
+      date: '',
+    },
+    imagePath: '',
+    html: '',
+  })
+
+  const stReference = reactive({
+    title: '',
+    version: '',
+    date: '',
+    author: '',
+    html: '',
+  })
+
+  const toeReference = reactive({
+    toeName: '',
+    toeVersion: '',
+    toeIdentification: '',
+    toeType: '',
+    html: '',
+  })
+
+  const toeOverview = reactive({
+    overview: '',
+    toeType: '',
+    toeUsage: '',
+    securityFeatures: '',
+    nonToe: '',
+    html: '',
+  })
+
+  const toeDescription = reactive({
+    physicalScope: '',
+    logicalScope: '',
+    html: '',
+  })
+
+  const stIntroductionDocxPath = ref('')
+
+  function ensureUserId() {
+    if (typeof window === 'undefined') return
+    if (userId.value) return
+
+    const existing = window.localStorage.getItem(storageKey)
+    if (existing) {
+      userId.value = existing
+      return
+    }
+
+    const generated = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2)
+    userId.value = generated
+    window.localStorage.setItem(storageKey, generated)
+  }
+
+  function applyCoverData(payload: any) {
+    if (!payload) return
+    const data = payload.data ?? payload.fields ?? {}
+    if (data.fields && typeof data.fields === 'object') {
+      Object.assign(cover.fields, data.fields)
+    } else {
+      Object.assign(cover.fields, data)
+    }
+    if (typeof data.image_path === 'string') {
+      cover.imagePath = data.image_path
+    } else if (typeof payload.image_path === 'string') {
+      cover.imagePath = payload.image_path
+    }
+    if (typeof payload.html === 'string') {
+      cover.html = payload.html
+    }
+  }
+
+  function applySimpleSection(target: Record<string, any>, payload: any) {
+    if (!payload) return
+    const data = payload.data ?? {}
+    if (data && typeof data === 'object') {
+      Object.assign(target, data)
+    }
+    if (typeof payload.html === 'string') {
+      target.html = payload.html
+    }
+  }
+
+  async function initialize() {
+    if (initialized.value || initializing.value) return
+
+    ensureUserId()
+    if (!userId.value) return
+
+    initializing.value = true
+    try {
+      const response = await api.get(`/session/${userId.value}`)
+      const sections = response.data?.sections ?? {}
+      applyCoverData(sections.cover)
+      applySimpleSection(stReference, sections.st_reference)
+      applySimpleSection(toeReference, sections.toe_reference)
+      applySimpleSection(toeOverview, sections.toe_overview)
+      applySimpleSection(toeDescription, sections.toe_description)
+    } catch (error) {
+      console.error('Failed to load session data', error)
+    } finally {
+      initializing.value = false
+      initialized.value = true
+    }
+  }
+
+  async function saveSection(section: SectionKey, payload: { data?: Record<string, any>; html?: string }) {
+    ensureUserId()
+    if (!userId.value) throw new Error('Unable to determine user session identifier.')
+
+    const request: Record<string, any> = {
+      user_id: userId.value,
+      section: SECTION_TO_SERVER[section],
+    }
+
+    if (payload.data !== undefined) {
+      request.data = payload.data
+    }
+
+    if (payload.html !== undefined) {
+      request.html_content = payload.html
+    }
+
+    await api.post('/session/section', request)
+  }
+
+  function setStIntroductionDocxPath(path: string) {
+    stIntroductionDocxPath.value = path
+  }
+
+  function clearStIntroductionDocxPath() {
+    stIntroductionDocxPath.value = ''
+  }
+
+  return {
+    userId,
+    cover,
+    stReference,
+    toeReference,
+    toeOverview,
+    toeDescription,
+    stIntroductionDocxPath,
+    initializing,
+    initialized,
+    ensureUserId,
+    initialize,
+    saveSection,
+    setStIntroductionDocxPath,
+    clearStIntroductionDocxPath,
+  }
+})

--- a/web/src/utils/html.ts
+++ b/web/src/utils/html.ts
@@ -1,0 +1,27 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function formatMultilineText(value: string): string {
+  if (!value) return ''
+  return escapeHtml(value).replace(/\r?\n/g, '<br />')
+}
+
+export function ensureParagraph(html: string, fallback = '—'): string {
+  if (!html || !html.trim()) {
+    return `<p>${escapeHtml(fallback)}</p>`
+  }
+  return html
+}
+
+export function safeText(value: string, fallback = '—'): string {
+  if (!value || !value.trim()) {
+    return escapeHtml(fallback)
+  }
+  return escapeHtml(value)
+}

--- a/web/src/views/StIntroductionPreview.vue
+++ b/web/src/views/StIntroductionPreview.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="st-intro-page">
+    <div class="card section-header">
+      <h1>ST Introduction Preview</h1>
+      <p class="section-subtitle">
+        Combine the Cover, ST Reference, TOE Reference, TOE Overview, and TOE Description sections into a single document.
+      </p>
+    </div>
+
+    <div class="card readiness-card">
+      <h2>Section Status</h2>
+      <ul>
+        <li v-for="section in sectionStatus" :key="section.key">
+          <span>{{ section.label }}</span>
+          <span :class="['badge', section.ready ? 'ok' : 'degraded']">{{ section.ready ? 'Ready' : 'Missing' }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <div class="card actions-card">
+      <div class="actions">
+        <button class="btn primary" type="button" @click="generatePreview" :disabled="previewLoading">
+          {{ previewLoading ? 'Generating…' : 'Generate Preview' }}
+        </button>
+        <a
+          v-if="downloadUrl"
+          class="btn"
+          :href="downloadUrl"
+          download
+        >Download DOCX</a>
+      </div>
+      <p class="hint">Ensure each section is filled before generating the preview.</p>
+    </div>
+
+    <div class="card preview-card">
+      <h2>Preview</h2>
+      <div class="preview-shell">
+        <div v-if="previewLoading" class="preview-status">Generating preview…</div>
+        <div v-else-if="previewError" class="preview-error">{{ previewError }}</div>
+        <div
+          v-else
+          ref="previewContainer"
+          class="docx-preview-container"
+          :class="{ hidden: !docxPath }"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { renderAsync } from 'docx-preview'
+import api from '../services/api'
+import { useSessionStore } from '../stores/session'
+
+const sessionStore = useSessionStore()
+const previewContainer = ref<HTMLDivElement | null>(null)
+const previewLoading = ref(false)
+const previewError = ref('')
+const docxPath = ref('')
+let beforeUnloadHandler: (() => void) | null = null
+
+const sectionStatus = computed(() => [
+  { key: 'cover', label: 'Cover', ready: !!sessionStore.cover.html },
+  { key: 'stReference', label: 'ST Reference', ready: !!sessionStore.stReference.html },
+  { key: 'toeReference', label: 'TOE Reference', ready: !!sessionStore.toeReference.html },
+  { key: 'toeOverview', label: 'TOE Overview', ready: !!sessionStore.toeOverview.html },
+  { key: 'toeDescription', label: 'TOE Description', ready: !!sessionStore.toeDescription.html },
+])
+
+const downloadUrl = computed(() => (docxPath.value ? api.getUri({ url: docxPath.value }) : ''))
+
+function attachUnloadListeners() {
+  if (typeof window === 'undefined' || beforeUnloadHandler) return
+  beforeUnloadHandler = () => {
+    cleanupDocx(true)
+  }
+  window.addEventListener('beforeunload', beforeUnloadHandler)
+  window.addEventListener('pagehide', beforeUnloadHandler)
+}
+
+function detachUnloadListeners() {
+  if (typeof window === 'undefined' || !beforeUnloadHandler) return
+  window.removeEventListener('beforeunload', beforeUnloadHandler)
+  window.removeEventListener('pagehide', beforeUnloadHandler)
+  beforeUnloadHandler = null
+}
+
+async function renderDocx(path: string) {
+  if (!previewContainer.value) return
+  try {
+    previewContainer.value.innerHTML = ''
+    const response = await api.get(path, { responseType: 'arraybuffer' })
+    const buffer = response.data as ArrayBuffer
+    await renderAsync(buffer, previewContainer.value, undefined, {
+      className: 'docx-rendered',
+      inWrapper: true,
+      ignoreWidth: false,
+      ignoreHeight: false,
+      useBase64URL: true,
+    })
+  } catch (error: any) {
+    previewError.value = error?.message || 'Unable to render preview.'
+  }
+}
+
+async function deleteExistingPreview() {
+  if (!sessionStore.userId || !docxPath.value) return
+  try {
+    await api.delete(`/st-introduction/preview/${sessionStore.userId}`)
+  } catch (error) {
+    console.warn('Failed to clean previous ST Introduction preview', error)
+  }
+  docxPath.value = ''
+  sessionStore.clearStIntroductionDocxPath()
+  if (previewContainer.value) {
+    previewContainer.value.innerHTML = ''
+  }
+}
+
+function cleanupDocx(keepalive = false) {
+  if (!sessionStore.userId || !docxPath.value) return
+  const url = api.getUri({ url: `/st-introduction/preview/${sessionStore.userId}` })
+  fetch(url, { method: 'DELETE', keepalive }).catch(() => undefined)
+  docxPath.value = ''
+  sessionStore.clearStIntroductionDocxPath()
+}
+
+async function generatePreview() {
+  previewError.value = ''
+  previewLoading.value = true
+  await sessionStore.initialize()
+
+  try {
+    await deleteExistingPreview()
+    if (!sessionStore.userId) {
+      throw new Error('Unable to determine user session identifier.')
+    }
+    const response = await api.post('/st-introduction/preview', {
+      user_id: sessionStore.userId,
+    })
+    const path: string | undefined = response.data?.path
+    if (!path) {
+      throw new Error('Preview generation did not return a document path.')
+    }
+    docxPath.value = path
+    sessionStore.setStIntroductionDocxPath(path)
+    await nextTick()
+    await renderDocx(path)
+    attachUnloadListeners()
+  } catch (error: any) {
+    previewError.value = error?.response?.data?.detail || error?.message || 'Unable to generate preview.'
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  await sessionStore.initialize()
+  const existingPath = sessionStore.stIntroductionDocxPath
+  if (existingPath) {
+    docxPath.value = existingPath
+    await nextTick()
+    await renderDocx(existingPath)
+    attachUnloadListeners()
+  }
+})
+
+onBeforeUnmount(() => {
+  detachUnloadListeners()
+})
+</script>
+
+<style scoped>
+.st-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.readiness-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.readiness-card li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 8px;
+  padding: 8px 12px;
+}
+
+.actions-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hint {
+  margin: 0;
+  color: var(--muted);
+}
+
+.preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preview-shell {
+  min-height: 240px;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.35);
+  position: relative;
+}
+
+.preview-status {
+  color: var(--muted);
+}
+
+.preview-error {
+  color: #f87171;
+}
+
+.docx-preview-container {
+  max-height: 480px;
+  overflow: auto;
+}
+
+.docx-preview-container.hidden {
+  display: none;
+}
+</style>

--- a/web/src/views/StReference.vue
+++ b/web/src/views/StReference.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="st-intro-page">
+    <div class="card section-header">
+      <h1>Security Target (ST) Reference</h1>
+      <p class="section-subtitle">Please describe the Security target references</p>
+    </div>
+    <div class="card">
+      <form class="form-grid" @submit.prevent>
+        <label>
+          <span>ST Title</span>
+          <input class="input" v-model="fields.title" type="text" placeholder="Enter the Security Target title" />
+        </label>
+        <label>
+          <span>ST Version</span>
+          <input class="input" v-model="fields.version" type="text" placeholder="Enter the version" />
+        </label>
+        <label>
+          <span>ST Date</span>
+          <input class="input" v-model="fields.date" type="date" />
+        </label>
+        <label class="full-width">
+          <span>Author</span>
+          <textarea
+            class="input textarea"
+            v-model="fields.author"
+            placeholder="List the authors contributing to the Security Target"
+          ></textarea>
+        </label>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useSessionStore } from '../stores/session'
+import { formatMultilineText, safeText } from '../utils/html'
+
+const sessionStore = useSessionStore()
+const fields = sessionStore.stReference
+const isReady = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function buildHtml(): string {
+  const title = safeText(fields.title)
+  const version = safeText(fields.version)
+  const date = safeText(fields.date)
+  const author = fields.author.trim() ? formatMultilineText(fields.author) : '—'
+
+  return `
+    <h2>1. Security Target Introduction</h2>
+    <p>This section presents the following information required for a Common Criteria (CC) evaluation:</p>
+    <ul>
+      <li>Identifies the Security Target (ST) and the Target of Evaluation (TOE)</li>
+      <li>Specifies the security target conventions,</li>
+      <li>Describes the organization of the security target</li>
+    </ul>
+    <h3>1.1 ST Reference</h3>
+    <table>
+      <tr><th>ST Title</th><td>${title}</td></tr>
+      <tr><th>ST Version</th><td>${version}</td></tr>
+      <tr><th>ST Date</th><td>${date}</td></tr>
+      <tr><th>Author</th><td>${author}</td></tr>
+    </table>
+    <p>Table 1 Security Target reference</p>
+  `
+}
+
+async function persist() {
+  if (!isReady.value) return
+  const html = buildHtml()
+  fields.html = html
+  try {
+    await sessionStore.saveSection('stReference', {
+      data: {
+        title: fields.title,
+        version: fields.version,
+        date: fields.date,
+        author: fields.author,
+      },
+      html,
+    })
+  } catch (error) {
+    console.error('Failed to persist ST Reference data', error)
+  }
+}
+
+function scheduleSave() {
+  if (!isReady.value) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    saveTimer = null
+    void persist()
+  }, 400)
+}
+
+onMounted(async () => {
+  await sessionStore.initialize()
+  isReady.value = true
+  if (!fields.html) {
+    await persist()
+  }
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) clearTimeout(saveTimer)
+})
+
+watch(
+  [
+    () => fields.title,
+    () => fields.version,
+    () => fields.date,
+    () => fields.author,
+  ],
+  scheduleSave,
+  { deep: false }
+)
+</script>
+
+<style scoped>
+.st-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+</style>

--- a/web/src/views/ToeDescription.vue
+++ b/web/src/views/ToeDescription.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="st-intro-page">
+    <div class="card section-header">
+      <h1>Target of Evaluation (TOE) Description</h1>
+      <p class="section-subtitle">Please describe your Target of Evaluation physical and logical scope</p>
+    </div>
+    <div class="card">
+      <form class="form-grid" @submit.prevent>
+        <label class="full-width">
+          <span>TOE Physical Scope</span>
+          <RichTextEditor
+            v-model="fields.physicalScope"
+            placeholder="Describe the TOE physical scope"
+          />
+        </label>
+        <label class="full-width">
+          <span>TOE Logical Scope</span>
+          <RichTextEditor
+            v-model="fields.logicalScope"
+            placeholder="Describe the TOE logical scope"
+          />
+        </label>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { ensureParagraph } from '../utils/html'
+
+const sessionStore = useSessionStore()
+const fields = sessionStore.toeDescription
+const isReady = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function buildHtml(): string {
+  return `
+    <h3>1.4 TOE Description</h3>
+    <h4>1.4.1 TOE Physical Scope</h4>
+    ${ensureParagraph(fields.physicalScope)}
+    <h4>1.4.2 TOE Logical Scope</h4>
+    ${ensureParagraph(fields.logicalScope)}
+  `
+}
+
+async function persist() {
+  if (!isReady.value) return
+  const html = buildHtml()
+  fields.html = html
+  try {
+    await sessionStore.saveSection('toeDescription', {
+      data: {
+        physicalScope: fields.physicalScope,
+        logicalScope: fields.logicalScope,
+      },
+      html,
+    })
+  } catch (error) {
+    console.error('Failed to persist TOE Description data', error)
+  }
+}
+
+function scheduleSave() {
+  if (!isReady.value) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    saveTimer = null
+    void persist()
+  }, 400)
+}
+
+onMounted(async () => {
+  await sessionStore.initialize()
+  isReady.value = true
+  if (!fields.html) {
+    await persist()
+  }
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) clearTimeout(saveTimer)
+})
+
+watch(
+  [
+    () => fields.physicalScope,
+    () => fields.logicalScope,
+  ],
+  scheduleSave,
+  { deep: false }
+)
+</script>
+
+<style scoped>
+.st-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+</style>

--- a/web/src/views/ToeOverview.vue
+++ b/web/src/views/ToeOverview.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="st-intro-page">
+    <div class="card section-header">
+      <h1>TOE Overview</h1>
+      <p class="section-subtitle">Please provide an overview of your TOE</p>
+    </div>
+    <div class="card">
+      <form class="form-grid" @submit.prevent>
+        <label class="full-width">
+          <span>TOE Overview</span>
+          <RichTextEditor
+            v-model="fields.overview"
+            placeholder="Describe your TOE in short (~100 words)"
+          />
+        </label>
+        <label class="full-width">
+          <span>TOE Type</span>
+          <RichTextEditor
+            v-model="fields.toeType"
+            placeholder="Describe the TOE type, device kind, functions, and features (~200 words)"
+          />
+        </label>
+        <label class="full-width">
+          <span>TOE Usage</span>
+          <RichTextEditor
+            v-model="fields.toeUsage"
+            placeholder="Describe how the TOE will be used and its intended environment"
+          />
+        </label>
+        <label class="full-width">
+          <span>TOE Major Security Features</span>
+          <RichTextEditor
+            v-model="fields.securityFeatures"
+            placeholder="Describe the TOE's major security features"
+          />
+        </label>
+        <label class="full-width">
+          <span>Non-TOE Hardware/Software/Firmware</span>
+          <RichTextEditor
+            v-model="fields.nonToe"
+            placeholder="Describe hardware/software/firmware excluded from the TOE"
+          />
+        </label>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { ensureParagraph } from '../utils/html'
+
+const sessionStore = useSessionStore()
+const fields = sessionStore.toeOverview
+const isReady = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function buildHtml(): string {
+  return `
+    <h3>1.3 TOE Overview</h3>
+    ${ensureParagraph(fields.overview)}
+    <h4>1.3.1 TOE Type</h4>
+    ${ensureParagraph(fields.toeType)}
+    <h4>1.3.2 TOE Usage</h4>
+    ${ensureParagraph(fields.toeUsage)}
+    <h4>1.3.3 TOE Major Security Features</h4>
+    ${ensureParagraph(fields.securityFeatures)}
+    <h4>1.3.4 Non-TOE Hardware/Software/Firmware</h4>
+    ${ensureParagraph(fields.nonToe)}
+  `
+}
+
+async function persist() {
+  if (!isReady.value) return
+  const html = buildHtml()
+  fields.html = html
+  try {
+    await sessionStore.saveSection('toeOverview', {
+      data: {
+        overview: fields.overview,
+        toeType: fields.toeType,
+        toeUsage: fields.toeUsage,
+        securityFeatures: fields.securityFeatures,
+        nonToe: fields.nonToe,
+      },
+      html,
+    })
+  } catch (error) {
+    console.error('Failed to persist TOE Overview data', error)
+  }
+}
+
+function scheduleSave() {
+  if (!isReady.value) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    saveTimer = null
+    void persist()
+  }, 400)
+}
+
+onMounted(async () => {
+  await sessionStore.initialize()
+  isReady.value = true
+  if (!fields.html) {
+    await persist()
+  }
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) clearTimeout(saveTimer)
+})
+
+watch(
+  [
+    () => fields.overview,
+    () => fields.toeType,
+    () => fields.toeUsage,
+    () => fields.securityFeatures,
+    () => fields.nonToe,
+  ],
+  scheduleSave,
+  { deep: false }
+)
+</script>
+
+<style scoped>
+.st-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+</style>

--- a/web/src/views/ToeReference.vue
+++ b/web/src/views/ToeReference.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="st-intro-page">
+    <div class="card section-header">
+      <h1>Target of Evaluation (TOE) Reference</h1>
+      <p class="section-subtitle">Please describe the Target of Evaluation references</p>
+    </div>
+    <div class="card">
+      <form class="form-grid" @submit.prevent>
+        <label>
+          <span>TOE Name</span>
+          <RichTextEditor v-model="fields.toeName" placeholder="Describe the TOE name" />
+        </label>
+        <label>
+          <span>TOE Version</span>
+          <RichTextEditor v-model="fields.toeVersion" placeholder="Provide the TOE version" />
+        </label>
+        <label>
+          <span>TOE Identification</span>
+          <RichTextEditor v-model="fields.toeIdentification" placeholder="Describe TOE identification details" />
+        </label>
+        <label>
+          <span>TOE Type</span>
+          <RichTextEditor v-model="fields.toeType" placeholder="Describe the TOE type" />
+        </label>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { ensureParagraph } from '../utils/html'
+
+const sessionStore = useSessionStore()
+const fields = sessionStore.toeReference
+const isReady = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function buildHtml(): string {
+  return `
+    <h3>1.2 TOE Reference</h3>
+    <table>
+      <tr><th>TOE Name</th><td>${ensureParagraph(fields.toeName)}</td></tr>
+      <tr><th>TOE Version</th><td>${ensureParagraph(fields.toeVersion)}</td></tr>
+      <tr><th>TOE Identification</th><td>${ensureParagraph(fields.toeIdentification)}</td></tr>
+      <tr><th>TOE Type</th><td>${ensureParagraph(fields.toeType)}</td></tr>
+    </table>
+    <p>Table 2 TOE reference</p>
+  `
+}
+
+async function persist() {
+  if (!isReady.value) return
+  const html = buildHtml()
+  fields.html = html
+  try {
+    await sessionStore.saveSection('toeReference', {
+      data: {
+        toeName: fields.toeName,
+        toeVersion: fields.toeVersion,
+        toeIdentification: fields.toeIdentification,
+        toeType: fields.toeType,
+      },
+      html,
+    })
+  } catch (error) {
+    console.error('Failed to persist TOE Reference data', error)
+  }
+}
+
+function scheduleSave() {
+  if (!isReady.value) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    saveTimer = null
+    void persist()
+  }, 400)
+}
+
+onMounted(async () => {
+  await sessionStore.initialize()
+  isReady.value = true
+  if (!fields.html) {
+    await persist()
+  }
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) clearTimeout(saveTimer)
+})
+
+watch(
+  [
+    () => fields.toeName,
+    () => fields.toeVersion,
+    () => fields.toeIdentification,
+    () => fields.toeType,
+  ],
+  scheduleSave,
+  { deep: false }
+)
+</script>
+
+<style scoped>
+.st-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 500;
+}
+</style>

--- a/web/tests/app.spec.ts
+++ b/web/tests/app.spec.ts
@@ -13,6 +13,21 @@ test.describe('CCGenTool navigation', () => {
     await expect(page.getByRole('heading', { name: 'Cover Image' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Preview Cover' })).toBeDisabled()
 
+    await page.getByRole('link', { name: 'ST Reference' }).click()
+    await expect(page.getByRole('heading', { name: 'Security Target (ST) Reference' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'TOE Reference' }).click()
+    await expect(page.getByRole('heading', { name: 'Target of Evaluation (TOE) Reference' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'TOE Overview' }).click()
+    await expect(page.getByRole('heading', { name: 'TOE Overview' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'TOE Description' }).click()
+    await expect(page.getByRole('heading', { name: 'Target of Evaluation (TOE) Description' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'ST Introduction Preview' }).click()
+    await expect(page.getByRole('heading', { name: 'ST Introduction Preview' })).toBeVisible()
+
     await page.getByRole('link', { name: 'Generator' }).first().click()
     await expect(page.getByRole('heading', { name: 'Security Target Generator' })).toBeVisible()
     await expect(page.getByText('Under Construction 🚧')).toBeVisible()


### PR DESCRIPTION
## Summary
- extend the FastAPI backend with session data storage and ST introduction docx generation
- add a Pinia-backed session store, reusable rich text editor, and new ST introduction views with autosave
- update the cover page persistence, sidebar navigation, and Playwright navigation test

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e4dcd86874832684567905b4d98179