### PR TITLE
Add ST introduction workflow with persistent sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 # Database
 *.db
 *.sqlite
+# Playwright
+web/test-results/

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="rich-text-wrapper">
+    <div
+      ref="editor"
+      class="rich-text-input"
+      :class="{ 'is-empty': isEmpty, disabled }"
+      :data-placeholder="placeholder"
+      contenteditable="true"
+      @input="handleInput"
+      @blur="emit('blur')"
+      @focus="emit('focus')"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  placeholder?: string
+  disabled?: boolean
+}>(), {
+  modelValue: '',
+  placeholder: '',
+  disabled: false,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+  (e: 'blur'): void
+  (e: 'focus'): void
+}>()
+
+const editor = ref<HTMLDivElement | null>(null)
+const isEmpty = ref(true)
+
+function sanitize(html: string): string {
+  return html.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+}
+
+function updatePlaceholderState() {
+  if (!editor.value) return
+  const textContent = editor.value.textContent?.trim() ?? ''
+  const hasStructuredContent = editor.value.querySelector('img,table,ul,ol,li,br,p,div') !== null
+  isEmpty.value = !textContent && !hasStructuredContent
+}
+
+function setContent(value: string) {
+  if (!editor.value) return
+  const sanitized = value || ''
+  if (editor.value.innerHTML !== sanitized) {
+    editor.value.innerHTML = sanitized
+  }
+  updatePlaceholderState()
+}
+
+function applyDisabledState() {
+  if (!editor.value) return
+  editor.value.setAttribute('contenteditable', props.disabled ? 'false' : 'true')
+}
+
+function handleInput() {
+  if (!editor.value) return
+  const sanitized = sanitize(editor.value.innerHTML)
+  emit('update:modelValue', sanitized)
+  updatePlaceholderState()
+}
+
+onMounted(() => {
+  setContent(props.modelValue)
+  applyDisabledState()
+})
+
+watch(() => props.modelValue, (value) => {
+  setContent(value)
+})
+
+watch(() => props.disabled, () => {
+  applyDisabledState()
+})
+</script>
+
+<style scoped>
+.rich-text-input {
+  min-height: 140px;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(15, 23, 42, 0.45);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.rich-text-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
+}
+
+.rich-text-input.is-empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.rich-text-input.disabled {
+  background: rgba(55, 65, 81, 0.35);
+  cursor: not-allowed;
+}
+</style>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,7 +4,22 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/cover" active-class="active">Cover Builder</RouterLink>
+      <div class="accordion">
+        <div class="accordion-header" @click="stOpen = !stOpen">
+          <span>ST Introduction</span>
+          <span>{{ stOpen ? '▾' : '▸' }}</span>
+        </div>
+        <div v-if="stOpen" class="accordion-content">
+          <ul class="menu">
+            <li><RouterLink to="/cover" active-class="active">Cover</RouterLink></li>
+            <li><RouterLink to="/st/introduction/reference" active-class="active">ST Reference</RouterLink></li>
+            <li><RouterLink to="/st/introduction/toe-reference" active-class="active">TOE Reference</RouterLink></li>
+            <li><RouterLink to="/st/introduction/toe-overview" active-class="active">TOE Overview</RouterLink></li>
+            <li><RouterLink to="/st/introduction/toe-description" active-class="active">TOE Description</RouterLink></li>
+            <li><RouterLink to="/st/introduction/preview" active-class="active">ST Introduction Preview</RouterLink></li>
+          </ul>
+        </div>
+      </div>
     </li>
     <li>
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
@@ -32,6 +47,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 const securityOpen = ref(true)
+const stOpen = ref(true)
 </script>
 
 <style scoped>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -5,10 +5,20 @@ import Generator from '../views/Generator.vue'
 import Settings from '../views/Settings.vue'
 import SecurityFunctionalRequirements from '../views/SecurityFunctionalRequirements.vue'
 import SecurityAssuranceRequirements from '../views/SecurityAssuranceRequirements.vue'
+import StReference from '../views/StReference.vue'
+import ToeReference from '../views/ToeReference.vue'
+import ToeOverview from '../views/ToeOverview.vue'
+import ToeDescription from '../views/ToeDescription.vue'
+import StIntroductionPreview from '../views/StIntroductionPreview.vue'
 
 const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/cover', name: 'cover', component: Cover },
+  { path: '/st/introduction/reference', name: 'st-reference', component: StReference },
+  { path: '/st/introduction/toe-reference', name: 'toe-reference', component: ToeReference },
+  { path: '/st/introduction/toe-overview', name: 'toe-overview', component: ToeOverview },
+  { path: '/st/introduction/toe-description', name: 'toe-description', component: ToeDescription },
+  { path: '/st/introduction/preview', name: 'st-introduction-preview', component: StIntroductionPreview },
   { path: '/generator', name: 'generator', component: Generator },
   { path: '/settings', name: 'settings', component: Settings },
   { path: '/security/sfr', name: 'security-sfr', component: SecurityFunctionalRequirements },

--- a/web/src/services/stIntroduction.ts
+++ b/web/src/services/stIntroduction.ts
@@ -1,0 +1,84 @@
+import api from './api'
+
+export interface CoverSavePayload {
+  user_id: string
+  title: string
+  version: string
+  revision: string
+  description: string
+  manufacturer: string
+  date: string
+  image_path?: string | null
+}
+
+export interface StReferencePayload {
+  user_id: string
+  st_title: string
+  st_version: string
+  st_date: string
+  author: string
+}
+
+export interface ToeReferencePayload {
+  user_id: string
+  toe_name: string
+  toe_version: string
+  toe_identification: string
+  toe_type: string
+}
+
+export interface ToeOverviewPayload {
+  user_id: string
+  overview: string
+  toe_type: string
+  toe_usage: string
+  toe_security_features: string
+  non_toe_hw: string
+}
+
+export interface ToeDescriptionPayload {
+  user_id: string
+  physical_scope: string
+  logical_scope: string
+}
+
+export async function saveCoverSection(payload: CoverSavePayload) {
+  const response = await api.post('/st-introduction/cover', payload)
+  return response.data
+}
+
+export async function saveStReference(payload: StReferencePayload) {
+  const response = await api.post('/st-introduction/st-reference', payload)
+  return response.data
+}
+
+export async function saveToeReference(payload: ToeReferencePayload) {
+  const response = await api.post('/st-introduction/toe-reference', payload)
+  return response.data
+}
+
+export async function saveToeOverview(payload: ToeOverviewPayload) {
+  const response = await api.post('/st-introduction/toe-overview', payload)
+  return response.data
+}
+
+export async function saveToeDescription(payload: ToeDescriptionPayload) {
+  const response = await api.post('/st-introduction/toe-description', payload)
+  return response.data
+}
+
+export async function fetchSession(userId: string) {
+  const response = await api.get(`/st-introduction/${userId}`)
+  return response.data
+}
+
+export async function generateStIntroductionPreview(userId: string) {
+  const response = await api.post('/st-introduction/preview', {
+    user_id: userId
+  })
+  return response.data
+}
+
+export async function cleanupStIntroductionPreview(userId: string) {
+  return api.delete(`/st-introduction/docx/${userId}`)
+}

--- a/web/src/stores/session.ts
+++ b/web/src/stores/session.ts
@@ -1,0 +1,246 @@
+import { defineStore } from 'pinia'
+import api from '../services/api'
+
+const storageKey = 'ccgen-user-id'
+
+type CoverFields = {
+  title: string
+  version: string
+  revision: string
+  description: string
+  manufacturer: string
+  date: string
+}
+
+type CoverSection = {
+  fields: CoverFields
+  image_path: string
+  html: string
+}
+
+type StReferenceFields = {
+  st_title: string
+  st_version: string
+  st_date: string
+  author: string
+}
+
+type SectionWithFields<T> = {
+  fields: T
+  html: string
+}
+
+type ToeReferenceFields = {
+  toe_name: string
+  toe_version: string
+  toe_identification: string
+  toe_type: string
+}
+
+type ToeReferenceSection = {
+  fields: ToeReferenceFields
+  rich_text: ToeReferenceFields
+  html: string
+}
+
+type ToeOverviewFields = {
+  overview: string
+  toe_type: string
+  toe_usage: string
+  toe_security_features: string
+  non_toe_hw: string
+}
+
+type ToeDescriptionFields = {
+  physical_scope: string
+  logical_scope: string
+}
+
+type SessionResponse = {
+  cover: CoverSection
+  st_reference: SectionWithFields<StReferenceFields>
+  toe_reference: ToeReferenceSection
+  toe_overview: SectionWithFields<ToeOverviewFields>
+  toe_description: SectionWithFields<ToeDescriptionFields>
+}
+
+export const useSessionStore = defineStore('session', {
+  state: () => ({
+    userId: '' as string,
+    loaded: false,
+    loading: false,
+    loadPromise: null as Promise<void> | null,
+    cover: {
+      fields: {
+        title: '',
+        version: '',
+        revision: '',
+        description: '',
+        manufacturer: '',
+        date: ''
+      },
+      image_path: '',
+      html: ''
+    } as CoverSection,
+    stReference: {
+      fields: {
+        st_title: '',
+        st_version: '',
+        st_date: '',
+        author: ''
+      },
+      html: ''
+    } as SectionWithFields<StReferenceFields>,
+    toeReference: {
+      fields: {
+        toe_name: '',
+        toe_version: '',
+        toe_identification: '',
+        toe_type: ''
+      },
+      rich_text: {
+        toe_name: '',
+        toe_version: '',
+        toe_identification: '',
+        toe_type: ''
+      },
+      html: ''
+    } as ToeReferenceSection,
+    toeOverview: {
+      fields: {
+        overview: '',
+        toe_type: '',
+        toe_usage: '',
+        toe_security_features: '',
+        non_toe_hw: ''
+      },
+      html: ''
+    } as SectionWithFields<ToeOverviewFields>,
+    toeDescription: {
+      fields: {
+        physical_scope: '',
+        logical_scope: ''
+      },
+      html: ''
+    } as SectionWithFields<ToeDescriptionFields>
+  }),
+  actions: {
+    ensureUserId(): string {
+      if (this.userId) return this.userId
+
+      if (typeof window === 'undefined') return ''
+
+      const existing = window.localStorage.getItem(storageKey)
+      if (existing) {
+        this.userId = existing
+        return existing
+      }
+
+      const generated = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2)
+
+      this.userId = generated
+      window.localStorage.setItem(storageKey, generated)
+      return generated
+    },
+    setUserId(id: string) {
+      this.userId = id
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(storageKey, id)
+      }
+    },
+    async loadSession(force = false): Promise<void> {
+      if (!this.userId) {
+        this.ensureUserId()
+      }
+
+      if (!this.userId) return
+
+      if (this.loaded && !force) {
+        return
+      }
+
+      if (this.loadPromise && !force) {
+        return this.loadPromise
+      }
+
+      this.loading = true
+      this.loadPromise = (async () => {
+        try {
+          const response = await api.get<SessionResponse>(`/st-introduction/${this.userId}`)
+          const data = response.data
+          if (data) {
+            this.cover = data.cover
+            this.stReference = data.st_reference
+            this.toeReference = data.toe_reference
+            this.toeOverview = data.toe_overview
+            this.toeDescription = data.toe_description
+          }
+        } catch (error) {
+          console.error('Failed to load ST introduction session data', error)
+        } finally {
+          this.loaded = true
+          this.loading = false
+          this.loadPromise = null
+        }
+      })()
+
+      return this.loadPromise
+    },
+    updateCover(section: Partial<CoverSection>) {
+      this.cover = {
+        ...this.cover,
+        ...section,
+        fields: {
+          ...this.cover.fields,
+          ...(section.fields ?? {})
+        }
+      }
+    },
+    updateStReference(section: Partial<SectionWithFields<StReferenceFields>>) {
+      this.stReference = {
+        ...this.stReference,
+        ...section,
+        fields: {
+          ...this.stReference.fields,
+          ...(section?.fields ?? {})
+        }
+      }
+    },
+    updateToeReference(section: Partial<ToeReferenceSection>) {
+      this.toeReference = {
+        ...this.toeReference,
+        ...section,
+        fields: {
+          ...this.toeReference.fields,
+          ...(section?.fields ?? {})
+        },
+        rich_text: {
+          ...this.toeReference.rich_text,
+          ...(section?.rich_text ?? {})
+        }
+      }
+    },
+    updateToeOverview(section: Partial<SectionWithFields<ToeOverviewFields>>) {
+      this.toeOverview = {
+        ...this.toeOverview,
+        ...section,
+        fields: {
+          ...this.toeOverview.fields,
+          ...(section?.fields ?? {})
+        }
+      }
+    },
+    updateToeDescription(section: Partial<SectionWithFields<ToeDescriptionFields>>) {
+      this.toeDescription = {
+        ...this.toeDescription,
+        ...section,
+        fields: {
+          ...this.toeDescription.fields,
+          ...(section?.fields ?? {})
+        }
+      }
+    }
+  }
+})

--- a/web/src/views/StIntroductionPreview.vue
+++ b/web/src/views/StIntroductionPreview.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="preview-page">
+    <div class="card intro-card">
+      <h1>ST Introduction Preview</h1>
+      <p>Generate a combined DOCX document containing the Cover, ST Reference, TOE Reference, TOE Overview, and TOE Description sections.</p>
+      <div class="preview-actions">
+        <button class="btn primary" type="button" @click="generatePreview" :disabled="previewLoading">Generate Preview</button>
+        <a v-if="docxPath" class="btn" :href="downloadUrl" download="st-introduction.docx">Download DOCX</a>
+      </div>
+      <p v-if="previewError" class="status error">{{ previewError }}</p>
+      <p v-else-if="previewLoading" class="status">Generating preview…</p>
+      <p v-else-if="docxPath" class="status success">Preview generated. You can download the DOCX file or review it below.</p>
+      <p v-else class="status">Changes are saved automatically. Generate a preview to see the combined output.</p>
+    </div>
+
+    <div class="card preview-card">
+      <div class="docx-preview-shell">
+        <div v-if="previewLoading" class="modal-status overlay">Generating preview…</div>
+        <div v-else-if="previewError" class="modal-error">{{ previewError }}</div>
+        <div
+          ref="docxPreviewContainer"
+          class="docx-preview-container"
+          :class="{ hidden: previewLoading || !!previewError || !docxPath }"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { renderAsync } from 'docx-preview'
+import api from '../services/api'
+import { useSessionStore } from '../stores/session'
+import { cleanupStIntroductionPreview, generateStIntroductionPreview } from '../services/stIntroduction'
+
+const session = useSessionStore()
+
+const previewLoading = ref(false)
+const previewError = ref('')
+const docxPath = ref<string | null>(null)
+const docxPreviewContainer = ref<HTMLDivElement | null>(null)
+
+const downloadUrl = computed(() => {
+  if (!docxPath.value) return '#'
+  return api.getUri({ url: docxPath.value })
+})
+
+async function generatePreview() {
+  if (!session.userId) {
+    session.ensureUserId()
+  }
+  if (!session.userId) {
+    previewError.value = 'Unable to determine user session identifier.'
+    return
+  }
+
+  await session.loadSession()
+
+  await cleanupPreview()
+
+  previewLoading.value = true
+  previewError.value = ''
+
+  try {
+    const response = await generateStIntroductionPreview(session.userId)
+    const path: string | undefined = response?.path
+    if (!path) {
+      throw new Error('Preview generation did not return a document path.')
+    }
+    docxPath.value = path
+    await nextTick()
+    await renderPreview(path)
+  } catch (error: any) {
+    previewError.value = error?.response?.data?.detail || error?.message || 'Unable to generate preview.'
+    await cleanupPreview()
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+async function renderPreview(path: string) {
+  if (!docxPreviewContainer.value) return
+  try {
+    docxPreviewContainer.value.innerHTML = ''
+    const response = await api.get(path, { responseType: 'arraybuffer' })
+    const buffer = response.data as ArrayBuffer
+    await renderAsync(buffer, docxPreviewContainer.value, undefined, {
+      className: 'docx-rendered',
+      inWrapper: true,
+      ignoreWidth: false,
+      ignoreHeight: false,
+      useBase64URL: true,
+    })
+  } catch (error: any) {
+    previewError.value = error?.message || 'Failed to render DOCX preview.'
+  }
+}
+
+async function cleanupPreview(keepalive = false) {
+  if (!session.userId || !docxPath.value) return
+  try {
+    if (keepalive) {
+      const url = api.getUri({ url: `/st-introduction/docx/${session.userId}` })
+      await fetch(url, { method: 'DELETE', keepalive: true }).catch(() => undefined)
+    } else {
+      await cleanupStIntroductionPreview(session.userId)
+    }
+  } catch {
+    // Ignore cleanup errors
+  } finally {
+    docxPath.value = null
+  }
+}
+
+function removeEventListeners() {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('beforeunload', handleBeforeUnload)
+  window.removeEventListener('pagehide', handlePageHide)
+}
+
+function handleBeforeUnload() {
+  void cleanupPreview(true)
+}
+
+function handlePageHide() {
+  void cleanupPreview(true)
+}
+
+onMounted(() => {
+  session.ensureUserId()
+  session.loadSession().catch(() => undefined)
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('pagehide', handlePageHide)
+  }
+})
+
+onBeforeUnmount(() => {
+  void cleanupPreview()
+  removeEventListeners()
+})
+</script>
+
+<style scoped>
+.preview-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preview-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.status {
+  margin-top: 12px;
+  color: var(--muted);
+}
+
+.status.success {
+  color: var(--success);
+}
+
+.status.error,
+.modal-error {
+  color: var(--danger);
+}
+
+.preview-card {
+  padding: 0;
+}
+
+.docx-preview-shell {
+  position: relative;
+  min-height: 320px;
+  padding: 24px;
+}
+
+.docx-preview-container {
+  max-height: 640px;
+  overflow: auto;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.docx-preview-container.hidden {
+  display: none;
+}
+
+.modal-status.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.modal-error {
+  padding: 16px;
+  background: rgba(127, 29, 29, 0.3);
+  border-radius: 12px;
+}
+</style>

--- a/web/src/views/StReference.vue
+++ b/web/src/views/StReference.vue
@@ -1,0 +1,170 @@
+<template>
+  <div class="st-page">
+    <div class="card intro-card">
+      <h1>Security Target (ST) Reference</h1>
+      <p>Please describe the Security Target references.</p>
+    </div>
+
+    <div class="card form-card">
+      <div class="form-grid">
+        <div class="field">
+          <span class="field-label">ST Title</span>
+          <input class="input" v-model="form.st_title" type="text" placeholder="Enter ST title" />
+        </div>
+        <div class="field">
+          <span class="field-label">ST Version</span>
+          <input class="input" v-model="form.st_version" type="text" placeholder="Enter ST version" />
+        </div>
+        <div class="field">
+          <span class="field-label">ST Date</span>
+          <input class="input" v-model="form.st_date" type="date" />
+        </div>
+        <div class="field field-span">
+          <span class="field-label">Author</span>
+          <textarea class="input textarea" v-model="form.author" placeholder="Enter author information"></textarea>
+        </div>
+      </div>
+
+      <div class="save-status" :class="{ saving, error: !!saveError }">
+        <span v-if="saveError">{{ saveError }}</span>
+        <span v-else-if="saving">Saving…</span>
+        <span v-else-if="lastSaved">Saved {{ lastSavedLabel }}</span>
+        <span v-else>Changes are saved automatically.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { useSessionStore } from '../stores/session'
+import { saveStReference } from '../services/stIntroduction'
+
+const session = useSessionStore()
+
+const form = reactive({
+  st_title: '',
+  st_version: '',
+  st_date: '',
+  author: '',
+})
+
+const saving = ref(false)
+const saveError = ref('')
+const lastSaved = ref<Date | null>(null)
+const ready = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+const lastSavedLabel = computed(() => {
+  if (!lastSaved.value) return ''
+  return lastSaved.value.toLocaleTimeString()
+})
+
+function scheduleSave() {
+  if (!ready.value || !session.userId) return
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+  saveTimer = setTimeout(() => {
+    void persist()
+  }, 400)
+}
+
+async function persist() {
+  if (!session.userId) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    const payload = {
+      user_id: session.userId,
+      st_title: form.st_title,
+      st_version: form.st_version,
+      st_date: form.st_date,
+      author: form.author,
+    }
+    const result = await saveStReference(payload)
+    session.updateStReference(result)
+    lastSaved.value = new Date()
+  } catch (error: any) {
+    console.error('Failed to save ST Reference', error)
+    saveError.value = error?.response?.data?.detail || 'Unable to save data.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  session.ensureUserId()
+  await session.loadSession()
+
+  Object.assign(form, session.stReference.fields)
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+})
+
+watch(form, () => {
+  if (!ready.value) return
+  scheduleSave()
+}, { deep: true })
+</script>
+
+<style scoped>
+.st-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.intro-card h1 {
+  margin-bottom: 8px;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-span {
+  grid-column: 1 / -1;
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.save-status {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.save-status.saving {
+  color: var(--text);
+}
+
+.save-status.error {
+  color: var(--danger);
+}
+</style>

--- a/web/src/views/ToeDescription.vue
+++ b/web/src/views/ToeDescription.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="st-page">
+    <div class="card intro-card">
+      <h1>Target of Evaluation (TOE) Description</h1>
+      <p>Please describe your TOE physical boundary scope and logical boundary scope.</p>
+    </div>
+
+    <div class="card form-card">
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Physical Scope</h2>
+          <p>Describe the physical scope of the TOE.</p>
+        </div>
+        <RichTextEditor v-model="form.physical_scope" placeholder="Describe the TOE physical scope" />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Logical Scope</h2>
+          <p>Describe the logical scope of the TOE.</p>
+        </div>
+        <RichTextEditor v-model="form.logical_scope" placeholder="Describe the TOE logical scope" />
+      </div>
+
+      <div class="save-status" :class="{ saving, error: !!saveError }">
+        <span v-if="saveError">{{ saveError }}</span>
+        <span v-else-if="saving">Saving…</span>
+        <span v-else-if="lastSaved">Saved {{ lastSavedLabel }}</span>
+        <span v-else>Changes are saved automatically.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { saveToeDescription } from '../services/stIntroduction'
+
+const session = useSessionStore()
+
+const form = reactive({
+  physical_scope: '',
+  logical_scope: '',
+})
+
+const saving = ref(false)
+const saveError = ref('')
+const lastSaved = ref<Date | null>(null)
+const ready = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+const lastSavedLabel = computed(() => {
+  if (!lastSaved.value) return ''
+  return lastSaved.value.toLocaleTimeString()
+})
+
+function scheduleSave() {
+  if (!ready.value || !session.userId) return
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+  saveTimer = setTimeout(() => {
+    void persist()
+  }, 400)
+}
+
+async function persist() {
+  if (!session.userId) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    const payload = {
+      user_id: session.userId,
+      physical_scope: form.physical_scope,
+      logical_scope: form.logical_scope,
+    }
+    const result = await saveToeDescription(payload)
+    session.updateToeDescription(result)
+    lastSaved.value = new Date()
+  } catch (error: any) {
+    console.error('Failed to save TOE Description', error)
+    saveError.value = error?.response?.data?.detail || 'Unable to save data.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  session.ensureUserId()
+  await session.loadSession()
+  Object.assign(form, session.toeDescription.fields)
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+})
+
+watch(form, () => {
+  if (!ready.value) return
+  scheduleSave()
+}, { deep: true })
+</script>
+
+<style scoped>
+.st-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-header h2 {
+  margin: 0 0 4px;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.save-status {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.save-status.saving {
+  color: var(--text);
+}
+
+.save-status.error {
+  color: var(--danger);
+}
+</style>

--- a/web/src/views/ToeOverview.vue
+++ b/web/src/views/ToeOverview.vue
@@ -1,0 +1,179 @@
+<template>
+  <div class="st-page">
+    <div class="card intro-card">
+      <h1>TOE Overview</h1>
+      <p>Please provide high-level information about your TOE.</p>
+    </div>
+
+    <div class="card form-card">
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Overview</h2>
+          <p>Please describe your TOE in a short sentence (~100 words).</p>
+        </div>
+        <RichTextEditor v-model="form.overview" placeholder="Provide a short TOE overview" />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Type</h2>
+          <p>Please describe your TOE Type (device, function, features) in ~200 words.</p>
+        </div>
+        <RichTextEditor v-model="form.toe_type" placeholder="Describe the TOE type" />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Usage</h2>
+          <p>Please describe how your TOE will be used and its intended environment.</p>
+        </div>
+        <RichTextEditor v-model="form.toe_usage" placeholder="Describe TOE usage" />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <h2>TOE Major Security Features</h2>
+          <p>Describe the security features your TOE provides (e.g., firewall, encryption).</p>
+        </div>
+        <RichTextEditor v-model="form.toe_security_features" placeholder="List TOE security features" />
+      </div>
+
+      <div class="section">
+        <div class="section-header">
+          <h2>Non-TOE Hardware/Software/Firmware</h2>
+          <p>Describe hardware/software/firmware excluded from the TOE (not evaluated).</p>
+        </div>
+        <RichTextEditor v-model="form.non_toe_hw" placeholder="Describe non-TOE hardware/software/firmware" />
+      </div>
+
+      <div class="save-status" :class="{ saving, error: !!saveError }">
+        <span v-if="saveError">{{ saveError }}</span>
+        <span v-else-if="saving">Saving…</span>
+        <span v-else-if="lastSaved">Saved {{ lastSavedLabel }}</span>
+        <span v-else>Changes are saved automatically.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { saveToeOverview } from '../services/stIntroduction'
+
+const session = useSessionStore()
+
+const form = reactive({
+  overview: '',
+  toe_type: '',
+  toe_usage: '',
+  toe_security_features: '',
+  non_toe_hw: '',
+})
+
+const saving = ref(false)
+const saveError = ref('')
+const lastSaved = ref<Date | null>(null)
+const ready = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+const lastSavedLabel = computed(() => {
+  if (!lastSaved.value) return ''
+  return lastSaved.value.toLocaleTimeString()
+})
+
+function scheduleSave() {
+  if (!ready.value || !session.userId) return
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+  saveTimer = setTimeout(() => {
+    void persist()
+  }, 400)
+}
+
+async function persist() {
+  if (!session.userId) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    const payload = {
+      user_id: session.userId,
+      overview: form.overview,
+      toe_type: form.toe_type,
+      toe_usage: form.toe_usage,
+      toe_security_features: form.toe_security_features,
+      non_toe_hw: form.non_toe_hw,
+    }
+    const result = await saveToeOverview(payload)
+    session.updateToeOverview(result)
+    lastSaved.value = new Date()
+  } catch (error: any) {
+    console.error('Failed to save TOE Overview', error)
+    saveError.value = error?.response?.data?.detail || 'Unable to save data.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  session.ensureUserId()
+  await session.loadSession()
+  Object.assign(form, session.toeOverview.fields)
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+})
+
+watch(form, () => {
+  if (!ready.value) return
+  scheduleSave()
+}, { deep: true })
+</script>
+
+<style scoped>
+.st-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-header h2 {
+  margin: 0 0 4px;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.save-status {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.save-status.saving {
+  color: var(--text);
+}
+
+.save-status.error {
+  color: var(--danger);
+}
+</style>

--- a/web/src/views/ToeReference.vue
+++ b/web/src/views/ToeReference.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="st-page">
+    <div class="card intro-card">
+      <h1>Target of Evaluation (TOE) Reference</h1>
+      <p>Please describe the Target of Evaluation references.</p>
+    </div>
+
+    <div class="card form-card">
+      <div class="field">
+        <span class="field-label">TOE Name</span>
+        <RichTextEditor v-model="form.toe_name" placeholder="Describe the TOE name" />
+      </div>
+      <div class="field">
+        <span class="field-label">TOE Version</span>
+        <RichTextEditor v-model="form.toe_version" placeholder="Describe the TOE version" />
+      </div>
+      <div class="field">
+        <span class="field-label">TOE Identification</span>
+        <RichTextEditor v-model="form.toe_identification" placeholder="Describe the TOE identification" />
+      </div>
+      <div class="field">
+        <span class="field-label">TOE Type</span>
+        <RichTextEditor v-model="form.toe_type" placeholder="Describe the TOE type" />
+      </div>
+
+      <div class="save-status" :class="{ saving, error: !!saveError }">
+        <span v-if="saveError">{{ saveError }}</span>
+        <span v-else-if="saving">Saving…</span>
+        <span v-else-if="lastSaved">Saved {{ lastSavedLabel }}</span>
+        <span v-else>Changes are saved automatically.</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import RichTextEditor from '../components/RichTextEditor.vue'
+import { useSessionStore } from '../stores/session'
+import { saveToeReference } from '../services/stIntroduction'
+
+const session = useSessionStore()
+
+const form = reactive({
+  toe_name: '',
+  toe_version: '',
+  toe_identification: '',
+  toe_type: '',
+})
+
+const saving = ref(false)
+const saveError = ref('')
+const lastSaved = ref<Date | null>(null)
+const ready = ref(false)
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+const lastSavedLabel = computed(() => {
+  if (!lastSaved.value) return ''
+  return lastSaved.value.toLocaleTimeString()
+})
+
+function scheduleSave() {
+  if (!ready.value || !session.userId) return
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+  saveTimer = setTimeout(() => {
+    void persist()
+  }, 400)
+}
+
+async function persist() {
+  if (!session.userId) return
+  saving.value = true
+  saveError.value = ''
+  try {
+    const payload = {
+      user_id: session.userId,
+      toe_name: form.toe_name,
+      toe_version: form.toe_version,
+      toe_identification: form.toe_identification,
+      toe_type: form.toe_type,
+    }
+    const result = await saveToeReference(payload)
+    session.updateToeReference(result)
+    lastSaved.value = new Date()
+  } catch (error: any) {
+    console.error('Failed to save TOE Reference', error)
+    saveError.value = error?.response?.data?.detail || 'Unable to save data.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  session.ensureUserId()
+  await session.loadSession()
+  Object.assign(form, session.toeReference.rich_text)
+  ready.value = true
+})
+
+onBeforeUnmount(() => {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+  }
+})
+
+watch(form, () => {
+  if (!ready.value) return
+  scheduleSave()
+}, { deep: true })
+</script>
+
+<style scoped>
+.st-page {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.save-status {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.save-status.saving {
+  color: var(--text);
+}
+
+.save-status.error {
+  color: var(--danger);
+}
+</style>


### PR DESCRIPTION
## Summary
- persist ST Introduction sections server-side and expose preview generation endpoints
- add Pinia session store, ST Introduction views, and reusable rich text editor on the frontend
- ignore Playwright test artifacts in version control

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e4dcd86874832684567905b4d98179