### PR TITLE
Add ST introduction workflow and persistence

### DIFF
--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="rich-text-editor">
+    <label v-if="label" :for="id" class="editor-label">{{ label }}</label>
+    <div class="toolbar" v-if="showToolbar">
+      <button type="button" class="btn" @click="applyCommand('bold')" title="Bold"><strong>B</strong></button>
+      <button type="button" class="btn" @click="applyCommand('italic')" title="Italic"><em>I</em></button>
+      <button type="button" class="btn" @click="applyCommand('underline')" title="Underline"><u>U</u></button>
+      <button type="button" class="btn" @click="applyCommand('insertUnorderedList')" title="Bullet list">• List</button>
+      <button type="button" class="btn" @click="applyCommand('insertOrderedList')" title="Numbered list">1. List</button>
+      <button type="button" class="btn" @click="applyCommand('undo')" title="Undo">↺</button>
+      <button type="button" class="btn" @click="applyCommand('redo')" title="Redo">↻</button>
+    </div>
+    <div
+      :id="id"
+      ref="editor"
+      class="editor"
+      contenteditable="true"
+      :data-placeholder="placeholder"
+      @input="onInput"
+      @blur="emitInput"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  label: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  id: { type: String, default: '' },
+  showToolbar: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const editor = ref<HTMLDivElement | null>(null)
+let isSettingContent = false
+
+function emitInput() {
+  if (!editor.value) return
+  const value = editor.value.innerHTML
+  emit('update:modelValue', value === '<br>' ? '' : value)
+}
+
+function onInput() {
+  if (isSettingContent) return
+  emitInput()
+}
+
+function applyCommand(command: string) {
+  document.execCommand(command, false, undefined)
+  emitInput()
+}
+
+onMounted(() => {
+  if (editor.value && props.modelValue) {
+    isSettingContent = true
+    editor.value.innerHTML = props.modelValue
+    isSettingContent = false
+  }
+})
+
+watch(
+  () => props.modelValue,
+  value => {
+    if (!editor.value) return
+    if (editor.value.innerHTML === value || (editor.value.innerHTML === '<br>' && !value)) {
+      return
+    }
+    isSettingContent = true
+    editor.value.innerHTML = value || ''
+    isSettingContent = false
+  }
+)
+</script>
+
+<style scoped>
+.rich-text-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.editor-label {
+  font-weight: 600;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.editor {
+  min-height: 140px;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(15, 23, 42, 0.35);
+  transition: border-color 0.2s ease;
+}
+
+.editor:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+}
+
+.editor:empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted);
+}
+</style>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,7 +4,22 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/cover" active-class="active">Cover Builder</RouterLink>
+      <div class="accordion">
+        <div class="accordion-header" @click="stOpen = !stOpen">
+          <span>ST Introduction</span>
+          <span>{{ stOpen ? '▾' : '▸' }}</span>
+        </div>
+        <div v-if="stOpen" class="accordion-content">
+          <ul class="menu nested">
+            <li><RouterLink to="/cover" active-class="active">Cover</RouterLink></li>
+            <li><RouterLink to="/st-introduction/reference" active-class="active">ST Reference</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-reference" active-class="active">TOE Reference</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-overview" active-class="active">TOE Overview</RouterLink></li>
+            <li><RouterLink to="/st-introduction/toe-description" active-class="active">TOE Description</RouterLink></li>
+            <li><RouterLink to="/st-introduction/preview" active-class="active">ST Introduction Preview</RouterLink></li>
+          </ul>
+        </div>
+      </div>
     </li>
     <li>
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
@@ -19,7 +34,7 @@
           <span>{{ securityOpen ? '▾' : '▸' }}</span>
         </div>
         <div v-if="securityOpen" class="accordion-content">
-          <ul class="menu">
+          <ul class="menu nested">
             <li><RouterLink to="/security/sfr" active-class="active">Security Functional Requirements</RouterLink></li>
             <li><RouterLink to="/security/sar" active-class="active">Security Assurance Requirements</RouterLink></li>
           </ul>
@@ -31,8 +46,62 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+
+const stOpen = ref(true)
 const securityOpen = ref(true)
 </script>
 
 <style scoped>
+.menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.menu > li > a,
+.menu.nested > li > a {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.2s ease;
+}
+
+.menu > li > a:hover,
+.menu.nested > li > a:hover {
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.active {
+  background: rgba(37, 99, 235, 0.35);
+  color: #fff;
+}
+
+.accordion {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.accordion-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.accordion-content {
+  padding: 8px;
+}
+
+.menu.nested {
+  gap: 4px;
+}
 </style>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -5,10 +5,20 @@ import Generator from '../views/Generator.vue'
 import Settings from '../views/Settings.vue'
 import SecurityFunctionalRequirements from '../views/SecurityFunctionalRequirements.vue'
 import SecurityAssuranceRequirements from '../views/SecurityAssuranceRequirements.vue'
+import STReference from '../views/STReference.vue'
+import ToeReference from '../views/ToeReference.vue'
+import ToeOverview from '../views/ToeOverview.vue'
+import ToeDescription from '../views/ToeDescription.vue'
+import StIntroductionPreview from '../views/StIntroductionPreview.vue'
 
 const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/cover', name: 'cover', component: Cover },
+  { path: '/st-introduction/reference', name: 'st-reference', component: STReference },
+  { path: '/st-introduction/toe-reference', name: 'toe-reference', component: ToeReference },
+  { path: '/st-introduction/toe-overview', name: 'toe-overview', component: ToeOverview },
+  { path: '/st-introduction/toe-description', name: 'toe-description', component: ToeDescription },
+  { path: '/st-introduction/preview', name: 'st-introduction-preview', component: StIntroductionPreview },
   { path: '/generator', name: 'generator', component: Generator },
   { path: '/settings', name: 'settings', component: Settings },
   { path: '/security/sfr', name: 'security-sfr', component: SecurityFunctionalRequirements },

--- a/web/src/services/stIntroductionService.ts
+++ b/web/src/services/stIntroductionService.ts
@@ -1,0 +1,43 @@
+import api from './api'
+import { StIntroductionSection } from '../stores/stIntroduction'
+
+export async function saveSectionHtml(userId: string, section: StIntroductionSection, html: string) {
+  try {
+    await api.post(`/st-introduction/sections/${section}`, {
+      user_id: userId,
+      html_content: html
+    })
+  } catch (error) {
+    console.error(`Failed to persist ST Introduction section "${section}":`, error)
+    throw error
+  }
+}
+
+export async function fetchSectionHtml(userId: string, section: StIntroductionSection) {
+  const response = await api.get(`/st-introduction/sections/${section}`, {
+    params: { user_id: userId }
+  })
+  return response.data?.html_content ?? ''
+}
+
+export async function generateStIntroductionPreview(userId: string) {
+  const response = await api.post('/st-introduction/preview', { user_id: userId })
+  return response.data as { path: string; html_content: string }
+}
+
+export async function cleanupStIntroductionPreview(userId: string) {
+  try {
+    await api.delete(`/st-introduction/preview/${userId}`)
+  } catch (error) {
+    console.error('Failed to clean ST Introduction preview:', error)
+  }
+}
+
+export async function cleanupStIntroductionSession(userId: string, keepalive = false) {
+  const url = api.getUri({ url: `/st-introduction/session/${userId}` })
+  try {
+    await fetch(url, { method: 'DELETE', keepalive })
+  } catch (error) {
+    console.error('Failed to clean ST Introduction session:', error)
+  }
+}

--- a/web/src/stores/stIntroduction.ts
+++ b/web/src/stores/stIntroduction.ts
@@ -1,0 +1,188 @@
+import { defineStore } from 'pinia'
+import { reactive, ref, watch } from 'vue'
+
+export type StIntroductionSection =
+  | 'cover'
+  | 'st-reference'
+  | 'toe-reference'
+  | 'toe-overview'
+  | 'toe-description'
+
+interface CoverFormState {
+  title: string
+  version: string
+  revision: string
+  description: string
+  manufacturer: string
+  date: string
+}
+
+interface StReferenceState {
+  stTitle: string
+  stVersion: string
+  stDate: string
+  author: string
+}
+
+interface ToeReferenceState {
+  toeName: string
+  toeVersion: string
+  toeIdentification: string
+  toeType: string
+}
+
+interface ToeOverviewState {
+  overview: string
+  toeType: string
+  usage: string
+  securityFeatures: string
+  nonToe: string
+}
+
+interface ToeDescriptionState {
+  physicalScope: string
+  logicalScope: string
+}
+
+interface PersistedState {
+  coverForm: CoverFormState
+  coverImagePath: string | null
+  stReference: StReferenceState
+  toeReference: ToeReferenceState
+  toeOverview: ToeOverviewState
+  toeDescription: ToeDescriptionState
+}
+
+const STORAGE_KEY = 'ccgentool2_st_introduction'
+
+function createDefaultState(): PersistedState {
+  return {
+    coverForm: {
+      title: '',
+      version: '',
+      revision: '',
+      description: '',
+      manufacturer: '',
+      date: ''
+    },
+    coverImagePath: null,
+    stReference: {
+      stTitle: '',
+      stVersion: '',
+      stDate: '',
+      author: ''
+    },
+    toeReference: {
+      toeName: '',
+      toeVersion: '',
+      toeIdentification: '',
+      toeType: ''
+    },
+    toeOverview: {
+      overview: '',
+      toeType: '',
+      usage: '',
+      securityFeatures: '',
+      nonToe: ''
+    },
+    toeDescription: {
+      physicalScope: '',
+      logicalScope: ''
+    }
+  }
+}
+
+export const useStIntroductionStore = defineStore('stIntroduction', () => {
+  const coverForm = reactive<CoverFormState>({ ...createDefaultState().coverForm })
+  const coverImagePath = ref<string | null>(null)
+  const stReference = reactive<StReferenceState>({ ...createDefaultState().stReference })
+  const toeReference = reactive<ToeReferenceState>({ ...createDefaultState().toeReference })
+  const toeOverview = reactive<ToeOverviewState>({ ...createDefaultState().toeOverview })
+  const toeDescription = reactive<ToeDescriptionState>({ ...createDefaultState().toeDescription })
+
+  function persist() {
+    if (typeof window === 'undefined') return
+    const payload: PersistedState = {
+      coverForm: { ...coverForm },
+      coverImagePath: coverImagePath.value,
+      stReference: { ...stReference },
+      toeReference: { ...toeReference },
+      toeOverview: { ...toeOverview },
+      toeDescription: { ...toeDescription }
+    }
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    } catch (error) {
+      console.error('Failed to persist ST Introduction state:', error)
+    }
+  }
+
+  function load() {
+    if (typeof window === 'undefined') return
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<PersistedState>
+      if (parsed.coverForm) {
+        Object.assign(coverForm, parsed.coverForm)
+      }
+      if (Object.prototype.hasOwnProperty.call(parsed, 'coverImagePath')) {
+        coverImagePath.value = parsed.coverImagePath ?? null
+      }
+      if (parsed.stReference) {
+        Object.assign(stReference, parsed.stReference)
+      }
+      if (parsed.toeReference) {
+        Object.assign(toeReference, parsed.toeReference)
+      }
+      if (parsed.toeOverview) {
+        Object.assign(toeOverview, parsed.toeOverview)
+      }
+      if (parsed.toeDescription) {
+        Object.assign(toeDescription, parsed.toeDescription)
+      }
+    } catch (error) {
+      console.error('Failed to load ST Introduction state:', error)
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    load()
+    watch(
+      () => ({
+        coverForm: { ...coverForm },
+        coverImagePath: coverImagePath.value,
+        stReference: { ...stReference },
+        toeReference: { ...toeReference },
+        toeOverview: { ...toeOverview },
+        toeDescription: { ...toeDescription }
+      }),
+      persist,
+      { deep: false }
+    )
+  }
+
+  function reset() {
+    const defaults = createDefaultState()
+    Object.assign(coverForm, defaults.coverForm)
+    coverImagePath.value = defaults.coverImagePath
+    Object.assign(stReference, defaults.stReference)
+    Object.assign(toeReference, defaults.toeReference)
+    Object.assign(toeOverview, defaults.toeOverview)
+    Object.assign(toeDescription, defaults.toeDescription)
+    persist()
+  }
+
+  return {
+    coverForm,
+    coverImagePath,
+    stReference,
+    toeReference,
+    toeOverview,
+    toeDescription,
+    reset,
+    persist,
+    load
+  }
+})

--- a/web/src/utils/debounce.ts
+++ b/web/src/utils/debounce.ts
@@ -1,0 +1,12 @@
+export function debounce<T extends (...args: any[]) => void>(fn: T, wait = 400) {
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  return (...args: Parameters<T>) => {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+    timeout = setTimeout(() => {
+      timeout = null
+      fn(...args)
+    }, wait)
+  }
+}

--- a/web/src/utils/stIntroductionHtml.ts
+++ b/web/src/utils/stIntroductionHtml.ts
@@ -1,0 +1,138 @@
+import { escapeHtml, formatMultilineText, fallbackParagraph } from './text'
+
+export interface CoverFormLike {
+  title: string
+  version: string
+  revision: string
+  description: string
+  manufacturer: string
+  date: string
+}
+
+export function buildCoverHtml(form: CoverFormLike, imagePath: string | null): string {
+  const title = escapeHtml(form.title || '')
+  const version = escapeHtml(form.version || '')
+  const revision = escapeHtml(form.revision || '')
+  const manufacturer = escapeHtml(form.manufacturer || '')
+  const date = escapeHtml(form.date || '')
+  const description = escapeHtml(form.description || '')
+
+  return `
+    <section>
+      <h2>Security Target Cover</h2>
+      <table>
+        <tbody>
+          <tr><th scope="row">Security Target Title</th><td>${title || '&mdash;'}</td></tr>
+          <tr><th scope="row">Security Target Version</th><td>${version || '&mdash;'}</td></tr>
+          <tr><th scope="row">Revision</th><td>${revision || '&mdash;'}</td></tr>
+          <tr><th scope="row">Manufacturer/Laboratory</th><td>${manufacturer || '&mdash;'}</td></tr>
+          <tr><th scope="row">Date</th><td>${date || '&mdash;'}</td></tr>
+          <tr><th scope="row">Cover Image</th><td>${imagePath ? 'Uploaded' : 'Not Provided'}</td></tr>
+        </tbody>
+      </table>
+      <p>${description || '&nbsp;'}</p>
+    </section>
+  `.trim()
+}
+
+export interface StReferenceLike {
+  stTitle: string
+  stVersion: string
+  stDate: string
+  author: string
+}
+
+export function buildStReferenceHtml(data: StReferenceLike): string {
+  const title = escapeHtml(data.stTitle || '')
+  const version = escapeHtml(data.stVersion || '')
+  const date = escapeHtml(data.stDate || '')
+  const author = formatMultilineText(data.author || '') || '&mdash;'
+
+  return `
+    <section>
+      <h2>1. Security Target Introduction</h2>
+      <p>This section presents the following information required for a Common Criteria (CC) evaluation:</p>
+      <ul>
+        <li>Identifies the Security Target (ST) and the Target of Evaluation (TOE)</li>
+        <li>Specifies the security target conventions</li>
+        <li>Describes the organization of the security target</li>
+      </ul>
+      <h3>1.1 ST Reference</h3>
+      <table>
+        <tbody>
+          <tr><th scope="row">ST Title</th><td>${title || '&mdash;'}</td></tr>
+          <tr><th scope="row">ST Version</th><td>${version || '&mdash;'}</td></tr>
+          <tr><th scope="row">ST Date</th><td>${date || '&mdash;'}</td></tr>
+          <tr><th scope="row">Author</th><td>${author}</td></tr>
+        </tbody>
+      </table>
+      <p><em>Table 1 Security Target reference</em></p>
+    </section>
+  `.trim()
+}
+
+export interface ToeReferenceLike {
+  toeName: string
+  toeVersion: string
+  toeIdentification: string
+  toeType: string
+}
+
+export function buildToeReferenceHtml(data: ToeReferenceLike): string {
+  return `
+    <section>
+      <h3>1.2 TOE Reference</h3>
+      <table>
+        <tbody>
+          <tr><th scope="row">TOE Name</th><td>${fallbackParagraph(data.toeName || '')}</td></tr>
+          <tr><th scope="row">TOE Version</th><td>${fallbackParagraph(data.toeVersion || '')}</td></tr>
+          <tr><th scope="row">TOE Identification</th><td>${fallbackParagraph(data.toeIdentification || '')}</td></tr>
+          <tr><th scope="row">TOE Type</th><td>${fallbackParagraph(data.toeType || '')}</td></tr>
+        </tbody>
+      </table>
+      <p><em>Table 2 TOE reference</em></p>
+    </section>
+  `.trim()
+}
+
+export interface ToeOverviewLike {
+  overview: string
+  toeType: string
+  usage: string
+  securityFeatures: string
+  nonToe: string
+}
+
+export function buildToeOverviewHtml(data: ToeOverviewLike): string {
+  return `
+    <section>
+      <h3>1.3 TOE Overview</h3>
+      ${fallbackParagraph(data.overview || '')}
+      <h4>1.3.1 TOE Type</h4>
+      ${fallbackParagraph(data.toeType || '')}
+      <h4>1.3.2 TOE Usage</h4>
+      ${fallbackParagraph(data.usage || '')}
+      <h4>1.3.3 TOE Major Security Features</h4>
+      ${fallbackParagraph(data.securityFeatures || '')}
+      <h4>1.3.4 Non-TOE Hardware/Software/Firmware</h4>
+      ${fallbackParagraph(data.nonToe || '')}
+    </section>
+  `.trim()
+}
+
+export interface ToeDescriptionLike {
+  physicalScope: string
+  logicalScope: string
+}
+
+export function buildToeDescriptionHtml(data: ToeDescriptionLike): string {
+  return `
+    <section>
+      <h3>1.4 TOE Description</h3>
+      <h4>1.4.1 TOE Physical Scope</h4>
+      ${fallbackParagraph(data.physicalScope || '')}
+      <h4>1.4.2 TOE Logical Scope</h4>
+      ${fallbackParagraph(data.logicalScope || '')}
+    </section>
+  `.trim()
+}

--- a/web/src/utils/text.ts
+++ b/web/src/utils/text.ts
@@ -1,0 +1,17 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function formatMultilineText(value: string): string {
+  if (!value) return ''
+  return escapeHtml(value).replace(/\r?\n/g, '<br />')
+}
+
+export function fallbackParagraph(content: string): string {
+  return content && content.trim() ? content : '<p>&mdash;</p>'
+}

--- a/web/src/utils/user.ts
+++ b/web/src/utils/user.ts
@@ -1,0 +1,25 @@
+const STORAGE_KEY = 'ccgen-user-id'
+
+export function getOrCreateUserId(): string {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
+  const existing = window.localStorage.getItem(STORAGE_KEY)
+  if (existing) {
+    return existing
+  }
+
+  const generated = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+  window.localStorage.setItem(STORAGE_KEY, generated)
+  return generated
+}
+
+export function clearUserId(): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.removeItem(STORAGE_KEY)
+}
+
+export { STORAGE_KEY as USER_ID_STORAGE_KEY }

--- a/web/src/views/STReference.vue
+++ b/web/src/views/STReference.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="page">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <h1>Security Target (ST) Reference</h1>
+          <p class="subtitle">Please describe the Security Target references</p>
+        </div>
+        <span class="status" :class="statusClass">{{ statusMessage }}</span>
+      </header>
+      <section class="form-grid">
+        <label>
+          <span>ST Title</span>
+          <input class="input" v-model="data.stTitle" type="text" placeholder="Enter ST Title" />
+        </label>
+        <label>
+          <span>ST Version</span>
+          <input class="input" v-model="data.stVersion" type="text" placeholder="Enter ST Version" />
+        </label>
+        <label>
+          <span>ST Date</span>
+          <input class="input" v-model="data.stDate" type="date" />
+        </label>
+        <label class="span-2">
+          <span>Author</span>
+          <textarea class="input textarea" v-model="data.author" rows="4" placeholder="Provide author details"></textarea>
+        </label>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useStIntroductionStore } from '../stores/stIntroduction'
+import { getOrCreateUserId } from '../utils/user'
+import { debounce } from '../utils/debounce'
+import { buildStReferenceHtml } from '../utils/stIntroductionHtml'
+import { saveSectionHtml } from '../services/stIntroductionService'
+
+const stStore = useStIntroductionStore()
+const { stReference: data } = storeToRefs(stStore)
+const userId = ref(getOrCreateUserId())
+
+const status = ref<'idle' | 'saving' | 'saved' | 'error'>('idle')
+const statusMessage = computed(() => {
+  switch (status.value) {
+    case 'saving':
+      return 'Saving…'
+    case 'saved':
+      return 'Saved'
+    case 'error':
+      return 'Save failed'
+    default:
+      return ''
+  }
+})
+const statusClass = computed(() => `status-${status.value}`)
+
+const persistSection = debounce(async () => {
+  if (!userId.value) return
+  const html = buildStReferenceHtml(data.value)
+  status.value = 'saving'
+  try {
+    await saveSectionHtml(userId.value, 'st-reference', html)
+    status.value = 'saved'
+  } catch (error) {
+    status.value = 'error'
+  }
+})
+
+watch(data, () => {
+  persistSection()
+}, { deep: true })
+
+persistSection()
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.span-2 {
+  grid-column: span 2;
+}
+
+.textarea {
+  resize: vertical;
+}
+
+.status {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.status-idle {
+  color: transparent;
+}
+
+.status-saving {
+  color: var(--muted);
+}
+
+.status-saved {
+  color: #34d399;
+}
+
+.status-error {
+  color: #f87171;
+}
+</style>

--- a/web/src/views/StIntroductionPreview.vue
+++ b/web/src/views/StIntroductionPreview.vue
@@ -1,0 +1,212 @@
+<template>
+  <div class="page">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <h1>ST Introduction Preview</h1>
+          <p class="subtitle">Generate and download a consolidated ST Introduction document.</p>
+        </div>
+        <div class="actions">
+          <button class="btn primary" type="button" @click="generatePreview" :disabled="previewLoading">
+            {{ previewLoading ? 'Generating…' : 'Generate Preview' }}
+          </button>
+          <a
+            v-if="docxPath"
+            class="btn"
+            :href="downloadHref"
+            target="_blank"
+            rel="noopener"
+            download
+          >Download DOCX</a>
+        </div>
+      </header>
+      <section class="preview-grid">
+        <div class="preview-pane">
+          <h2>Combined HTML</h2>
+          <div class="html-preview" v-if="combinedHtml" v-html="combinedHtml"></div>
+          <p v-else class="placeholder">No ST Introduction content available yet.</p>
+        </div>
+        <div class="preview-pane">
+          <h2>DOCX Preview</h2>
+          <div class="docx-preview-shell">
+            <div v-if="previewLoading" class="modal-status">Generating preview…</div>
+            <div v-else-if="previewError" class="modal-error">{{ previewError }}</div>
+            <div
+              ref="docxPreviewContainer"
+              class="docx-preview-container"
+              :class="{ hidden: previewLoading || !!previewError }"
+            ></div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { renderAsync } from 'docx-preview'
+import { getOrCreateUserId } from '../utils/user'
+import {
+  cleanupStIntroductionPreview,
+  cleanupStIntroductionSession,
+  generateStIntroductionPreview,
+} from '../services/stIntroductionService'
+import api from '../services/api'
+
+const userId = ref('')
+const combinedHtml = ref('')
+const docxPath = ref('')
+const previewLoading = ref(false)
+const previewError = ref('')
+const docxPreviewContainer = ref<HTMLDivElement | null>(null)
+
+const downloadHref = computed(() => docxPath.value ? api.getUri({ url: docxPath.value }) : '#')
+
+async function generatePreview() {
+  if (!userId.value) {
+    previewError.value = 'Unable to determine user session identifier.'
+    return
+  }
+  previewLoading.value = true
+  previewError.value = ''
+  await cleanupExistingPreview()
+  try {
+    const response = await generateStIntroductionPreview(userId.value)
+    combinedHtml.value = response.html_content
+    docxPath.value = response.path
+    await nextTick()
+    await renderDocxPreview()
+  } catch (error: any) {
+    previewError.value = error?.response?.data?.detail || error?.message || 'Failed to generate preview.'
+  } finally {
+    previewLoading.value = false
+  }
+}
+
+async function renderDocxPreview() {
+  if (!docxPreviewContainer.value || !docxPath.value) return
+  try {
+    docxPreviewContainer.value.innerHTML = ''
+    const response = await api.get(docxPath.value, { responseType: 'arraybuffer' })
+    const buffer = response.data as ArrayBuffer
+    await renderAsync(buffer, docxPreviewContainer.value, undefined, {
+      className: 'docx-rendered',
+      inWrapper: true,
+      ignoreWidth: false,
+      ignoreHeight: false,
+      useBase64URL: true,
+    })
+  } catch (error: any) {
+    previewError.value = error?.message || 'Failed to render DOCX preview.'
+  }
+}
+
+async function cleanupExistingPreview() {
+  if (!userId.value || !docxPath.value) return
+  await cleanupStIntroductionPreview(userId.value)
+  docxPath.value = ''
+}
+
+function handleBeforeUnload() {
+  if (!userId.value) return
+  cleanupStIntroductionSession(userId.value, true)
+}
+
+onMounted(() => {
+  userId.value = getOrCreateUserId()
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('pagehide', handleBeforeUnload)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('beforeunload', handleBeforeUnload)
+    window.removeEventListener('pagehide', handleBeforeUnload)
+  }
+  cleanupExistingPreview()
+})
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.preview-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.html-preview {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 10px;
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.25);
+  max-height: 420px;
+  overflow: auto;
+}
+
+.placeholder {
+  color: var(--muted);
+}
+
+.docx-preview-shell {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 10px;
+  min-height: 360px;
+  background: rgba(15, 23, 42, 0.25);
+  padding: 16px;
+}
+
+.docx-preview-container.hidden {
+  display: none;
+}
+
+.modal-status {
+  text-align: center;
+  padding: 32px 0;
+  color: var(--muted);
+}
+
+.modal-error {
+  color: #f87171;
+  padding: 16px;
+}
+</style>

--- a/web/src/views/ToeDescription.vue
+++ b/web/src/views/ToeDescription.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="page">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <h1>Target of Evaluation (TOE) Description</h1>
+          <p class="subtitle">Describe the TOE physical and logical boundary scope</p>
+        </div>
+        <span class="status" :class="statusClass">{{ statusMessage }}</span>
+      </header>
+      <section class="form-grid">
+        <RichTextEditor
+          label="TOE Physical Scope"
+          v-model="data.physicalScope"
+          placeholder="Describe the TOE physical scope"
+        />
+        <RichTextEditor
+          label="TOE Logical Scope"
+          v-model="data.logicalScope"
+          placeholder="Describe the TOE logical scope"
+        />
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useStIntroductionStore } from '../stores/stIntroduction'
+import { getOrCreateUserId } from '../utils/user'
+import { debounce } from '../utils/debounce'
+import { buildToeDescriptionHtml } from '../utils/stIntroductionHtml'
+import { saveSectionHtml } from '../services/stIntroductionService'
+import RichTextEditor from '../components/RichTextEditor.vue'
+
+const stStore = useStIntroductionStore()
+const { toeDescription: data } = storeToRefs(stStore)
+const userId = ref(getOrCreateUserId())
+
+const status = ref<'idle' | 'saving' | 'saved' | 'error'>('idle')
+const statusMessage = computed(() => {
+  switch (status.value) {
+    case 'saving':
+      return 'Saving…'
+    case 'saved':
+      return 'Saved'
+    case 'error':
+      return 'Save failed'
+    default:
+      return ''
+  }
+})
+const statusClass = computed(() => `status-${status.value}`)
+
+const persistSection = debounce(async () => {
+  if (!userId.value) return
+  status.value = 'saving'
+  try {
+    const html = buildToeDescriptionHtml(data.value)
+    await saveSectionHtml(userId.value, 'toe-description', html)
+    status.value = 'saved'
+  } catch (error) {
+    status.value = 'error'
+  }
+})
+
+watch(data, () => {
+  persistSection()
+}, { deep: true })
+
+persistSection()
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.status {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.status-idle {
+  color: transparent;
+}
+
+.status-saving {
+  color: var(--muted);
+}
+
+.status-saved {
+  color: #34d399;
+}
+
+.status-error {
+  color: #f87171;
+}
+</style>

--- a/web/src/views/ToeOverview.vue
+++ b/web/src/views/ToeOverview.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="page">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <h1>TOE Overview</h1>
+          <p class="subtitle">Provide an overview of your TOE and its characteristics</p>
+        </div>
+        <span class="status" :class="statusClass">{{ statusMessage }}</span>
+      </header>
+      <section class="form-grid">
+        <RichTextEditor
+          label="TOE Overview"
+          v-model="data.overview"
+          placeholder="Describe your TOE in ~100 words"
+        />
+        <RichTextEditor
+          label="TOE Type"
+          v-model="data.toeType"
+          placeholder="Describe your TOE type and features (~200 words)"
+        />
+        <RichTextEditor
+          label="TOE Usage"
+          v-model="data.usage"
+          placeholder="Describe how your TOE will be used and its intended environment"
+        />
+        <RichTextEditor
+          label="TOE Major Security Features"
+          v-model="data.securityFeatures"
+          placeholder="Describe the major security features of your TOE"
+        />
+        <RichTextEditor
+          label="Non-TOE Hardware/Software/Firmware"
+          v-model="data.nonToe"
+          placeholder="List excluded hardware/software/firmware"
+        />
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useStIntroductionStore } from '../stores/stIntroduction'
+import { getOrCreateUserId } from '../utils/user'
+import { debounce } from '../utils/debounce'
+import { buildToeOverviewHtml } from '../utils/stIntroductionHtml'
+import { saveSectionHtml } from '../services/stIntroductionService'
+import RichTextEditor from '../components/RichTextEditor.vue'
+
+const stStore = useStIntroductionStore()
+const { toeOverview: data } = storeToRefs(stStore)
+const userId = ref(getOrCreateUserId())
+
+const status = ref<'idle' | 'saving' | 'saved' | 'error'>('idle')
+const statusMessage = computed(() => {
+  switch (status.value) {
+    case 'saving':
+      return 'Saving…'
+    case 'saved':
+      return 'Saved'
+    case 'error':
+      return 'Save failed'
+    default:
+      return ''
+  }
+})
+const statusClass = computed(() => `status-${status.value}`)
+
+const persistSection = debounce(async () => {
+  if (!userId.value) return
+  status.value = 'saving'
+  try {
+    const html = buildToeOverviewHtml(data.value)
+    await saveSectionHtml(userId.value, 'toe-overview', html)
+    status.value = 'saved'
+  } catch (error) {
+    status.value = 'error'
+  }
+})
+
+watch(data, () => {
+  persistSection()
+}, { deep: true })
+
+persistSection()
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.status {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.status-idle {
+  color: transparent;
+}
+
+.status-saving {
+  color: var(--muted);
+}
+
+.status-saved {
+  color: #34d399;
+}
+
+.status-error {
+  color: #f87171;
+}
+</style>

--- a/web/src/views/ToeReference.vue
+++ b/web/src/views/ToeReference.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="page">
+    <div class="card">
+      <header class="card-header">
+        <div>
+          <h1>Target of Evaluation (TOE) Reference</h1>
+          <p class="subtitle">Please describe the Target of Evaluation references</p>
+        </div>
+        <span class="status" :class="statusClass">{{ statusMessage }}</span>
+      </header>
+      <section class="form-grid">
+        <RichTextEditor
+          label="TOE Name"
+          v-model="data.toeName"
+          placeholder="Enter TOE name"
+        />
+        <RichTextEditor
+          label="TOE Version"
+          v-model="data.toeVersion"
+          placeholder="Enter TOE version"
+        />
+        <RichTextEditor
+          label="TOE Identification"
+          v-model="data.toeIdentification"
+          placeholder="Describe the TOE identification"
+        />
+        <RichTextEditor
+          label="TOE Type"
+          v-model="data.toeType"
+          placeholder="Describe the TOE type"
+        />
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useStIntroductionStore } from '../stores/stIntroduction'
+import { getOrCreateUserId } from '../utils/user'
+import { debounce } from '../utils/debounce'
+import { buildToeReferenceHtml } from '../utils/stIntroductionHtml'
+import { saveSectionHtml } from '../services/stIntroductionService'
+import RichTextEditor from '../components/RichTextEditor.vue'
+
+const stStore = useStIntroductionStore()
+const { toeReference: data } = storeToRefs(stStore)
+const userId = ref(getOrCreateUserId())
+
+const status = ref<'idle' | 'saving' | 'saved' | 'error'>('idle')
+const statusMessage = computed(() => {
+  switch (status.value) {
+    case 'saving':
+      return 'Saving…'
+    case 'saved':
+      return 'Saved'
+    case 'error':
+      return 'Save failed'
+    default:
+      return ''
+  }
+})
+const statusClass = computed(() => `status-${status.value}`)
+
+const persistSection = debounce(async () => {
+  if (!userId.value) return
+  status.value = 'saving'
+  try {
+    const html = buildToeReferenceHtml(data.value)
+    await saveSectionHtml(userId.value, 'toe-reference', html)
+    status.value = 'saved'
+  } catch (error) {
+    status.value = 'error'
+  }
+})
+
+watch(data, () => {
+  persistSection()
+}, { deep: true })
+
+persistSection()
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  padding: 24px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.status {
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.status-idle {
+  color: transparent;
+}
+
+.status-saving {
+  color: var(--muted);
+}
+
+.status-saved {
+  color: #34d399;
+}
+
+.status-error {
+  color: #f87171;
+}
+</style>

--- a/web/tests/app.spec.ts
+++ b/web/tests/app.spec.ts
@@ -9,9 +9,18 @@ test.describe('CCGenTool navigation', () => {
     await expect(page.getByRole('link', { name: 'Create New Security Target' })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Automatically Generate Security Target' })).toBeVisible()
 
-    await page.getByRole('link', { name: 'Create New Security Target' }).click()
+    await page.getByRole('link', { name: 'Cover' }).click()
     await expect(page.getByRole('heading', { name: 'Cover Image' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Preview Cover' })).toBeDisabled()
+
+    await page.getByRole('link', { name: 'ST Reference' }).click()
+    await expect(page.getByRole('heading', { name: 'Security Target (ST) Reference' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'TOE Reference' }).click()
+    await expect(page.getByRole('heading', { name: 'Target of Evaluation (TOE) Reference' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'ST Introduction Preview' }).click()
+    await expect(page.getByRole('heading', { name: 'ST Introduction Preview' })).toBeVisible()
 
     await page.getByRole('link', { name: 'Generator' }).first().click()
     await expect(page.getByRole('heading', { name: 'Security Target Generator' })).toBeVisible()


### PR DESCRIPTION
## Summary
- add ST Introduction accordion navigation with new ST Reference, TOE Reference, TOE Overview, TOE Description, and preview views
- persist ST section content and cover data across navigation via Pinia store, API client, and FastAPI endpoints, including combined DOCX preview generation
- introduce shared rich text editor component and utilities for building ST introduction HTML fragments

## Testing
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68e4dcd86874832684567905b4d98179