### PR TITLE
Add module guides for server and web directories

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,83 @@
+# CCGenTool2 Server Contribution Guide
+
+## Runtime and External Modules
+- **FastAPI** (`fastapi.FastAPI`, `fastapi.Depends`, `fastapi.UploadFile`, `fastapi.File`, `fastapi.HTTPException`) powers the HTTP API surface that the Vue client calls.
+- **SQLAlchemy** (`sqlalchemy.create_engine`, `sqlalchemy.orm.Session`, ORM models) provides persistence, with optional PostgreSQL or SQLite backends.
+- **Pydantic v2** (`pydantic.BaseModel`, `pydantic.Field`, `pydantic.ConfigDict`) defines request/response schemas with alias support for `class` fields.
+- **python-docx** (`docx.Document` et al.) generates DOCX previews for cover pages, SFR/SAR sections, and ST introduction bundles.
+- **lxml** (`lxml.etree`, `lxml.html`) parses Common Criteria XML and sanitises HTML previews.
+- **Other helpers**: `tempfile`, `uuid`, `pathlib.Path`, and `asynccontextmanager` manage filesystem lifecycles for uploads and previews.
+
+## Module Map and Function Responsibilities
+### `app/database.py`
+- Configures the SQLAlchemy `engine` depending on `DATABASE_URL` (SQLite special casing) and exposes `SessionLocal` and declarative `Base`.
+- `get_db()` yields a request-scoped SQLAlchemy session that API endpoints depend upon.
+
+### `app/models.py`
+- Declares ORM tables:
+  - `Component` for generic XML component rows.
+  - `ComponentFamilyBase` mixin underpinning specific FA*/FP*/AC* tables (e.g. `FauDb`, `FcoDb`, `AcoDb`, `AdvDb`).
+  - `ElementListDb` captures coloured XML element lists.
+
+### `app/schemas.py`
+- Mirrors the ORM with Pydantic models:
+  - `ComponentBase`/`ComponentCreate`/`ComponentUpdate`/`ComponentOut` manage generic component payloads.
+  - `ComponentFamilyBase`/`ComponentFamilyCreate`/`ComponentFamilyUpdate`/`ComponentFamilyOut` handle family-specific tables using the alias `class_field`.
+  - `ElementListBase` + derivatives represent coloured element storage.
+  - `XmlParseResponse` & `XmlImportResponse` describe parser outcomes consumed by `/xml` routes.
+
+### `app/xml_parser_service.py`
+- `XmlNode` builds a navigable tree with `add_child()` and `to_dict()` used by preview endpoints.
+- `XmlParserService`
+  - Maintains `functional_table_mappings` and `assurance_table_mappings` that translate XML class IDs into ORM models.
+  - `parse_xml_file()` creates the `XmlNode` tree and extracts component dictionaries.
+  - `import_to_database()` orchestrates parsing, delegates to `_insert_component_to_table()`, collects failures, imports coloured element lists via `_extract_element_lists()` and `_insert_element_list_to_db()`, and commits.
+  - Helper methods `_get_table_class_for_class_id()`, `_get_table_name_for_class_id()`, `_normalize_text()`, `_parse_component_element()`, etc. (defined deeper in the file) normalise XML values before persistence.
+- This service is consumed by FastAPI endpoints (`/xml/parse`, `/xml/import`) and the CLI importer.
+
+### `app/main.py`
+- Lifecycle:
+  - `lifespan()` ensures tables exist on startup.
+  - Directory helpers (`get_user_upload_dir()`, `_get_preview_docx_dir()`, `get_user_docx_dir()`) standardise per-user storage.
+- Cover/ST document helpers:
+  - `_resolve_uploaded_image_path()`, `_format_cover_date()`, `_build_cover_document()`, `_append_html_to_document()`, `_build_html_preview_document()`, `_build_st_intro_combined_document()` convert stored data and HTML fragments into DOCX files using `python-docx`.
+  - Styling utilities (`_px_to_points()`, `_parse_margin_left()`, `_parse_color()`, `_collect_inline_styles()`, `_merge_styles()`, `_append_inline_content()`, `_append_block_element()`) interpret inline styles when rendering HTML previews.
+- Dependency helpers:
+  - `get_family_table_model()` maps requested table names to ORM classes using `XmlParserService` tables.
+- REST endpoints (dependency injection via `Depends(get_db)`):
+  - `/health` (`health`) issues a lightweight `SELECT 1` and returns latency.
+  - CRUD for `/components` (`list_components`, `create_component`, `get_component`, `update_component`, `delete_component`).
+  - XML ingestion (`parse_xml_file`, `import_xml_to_database`) delegates to `XmlParserService`.
+  - Family lookups (`list_family_tables`, `list_family_components`, `count_family_components`, `create_family_component`, `update_family_component`, `delete_family_component`).
+  - Element list retrieval/formatting (`list_element_lists`, `get_formatted_element_list`).
+  - Formatted family exports (`get_formatted_family_elements`).
+  - Upload & preview management (`upload_cover_image`, `generate_cover_preview`, `generate_sfr_preview`, `generate_sar_preview`, `generate_st_intro_preview`).
+  - Cleanup endpoints for each preview namespace to delete user-specific temp files.
+- Static assets from `/cover/uploads` and `/cover/docx` are served using `StaticFiles` (see mounting logic near the top of the file).
+
+### `app/__init__.py`
+- Marks the directory as a Python package.
+
+### `run.py`
+- CLI entry point for local dev using `uvicorn.run("app.main:app")` with autoreload.
+
+### `import_cc_data.py`
+- Batch importer utilising `XmlParserService` without FastAPI:
+  - `clear_tables()` bulk-deletes ORM rows using SQLAlchemy `delete`.
+  - `import_xml()` manages session lifecycle, optional reset, and prints summary metrics returned from the service.
+  - `default_xml_path()`, `parse_args()`, and `main()` wire the CLI flags.
+- Shares ORM models and parser with `app/main.py`, so keep interfaces aligned.
+
+## Cross-Module Relationships
+- FastAPI endpoints and the CLI importer both instantiate `XmlParserService` to keep XML parsing logic centralised.
+- Request handlers accept/return Pydantic models from `schemas.py`, which directly map to SQLAlchemy ORM entities defined in `models.py`.
+- Upload/preview helpers write files into directories derived from environment variables; cleanup endpoints must delete from the same locations to avoid orphaned files.
+
+## Testing Expectations
+1. Start dependencies (e.g. PostgreSQL) as directed in the repository root instructions, or fall back to SQLite for isolated checks.
+2. Launch the API with `uvicorn app.main:app --reload` (or `python run.py`).
+3. Run the Vue client and execute your change-specific user flows.
+4. Validate XML import paths by uploading `oldparser/cc.xml` through the web UI so that new endpoints see realistic data.
+5. Use Playwright-driven browser flows (see the `web/AGENTS.md` instructions) to exercise API mutations that rely on stateful interactions.
+
+Lastly, please test all your implementation, using your own tool like playwright, and take screenshot as your aid in debugging and for evidence.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,82 @@
+# CCGenTool2 Web Contribution Guide
+
+## Front-End Stack and Key Libraries
+- **Vue 3 + `<script setup>` composition API** for building single-file components.
+- **Pinia** (`createPinia`) for global state readiness (currently minimal but installed in `main.ts`).
+- **Vue Router** (`createRouter`, `createWebHistory`) for page navigation.
+- **Axios** for REST calls to the FastAPI backend (`src/services/api.ts`).
+- **TipTap** editor extensions (`@tiptap/*`) powering the rich text editor component.
+- **docx-preview** renders DOCX blobs returned by the API inside modals.
+- **Playwright** (`@playwright/test`) drives end-to-end smoke tests under `tests/` and must be used to validate UI flows.
+- **Vite** handles development and build tooling with TypeScript support.
+
+## Module Map and Function Responsibilities
+### Application Shell
+- `src/main.ts` bootstraps the Vue app, installs Pinia and the router, then mounts `App.vue`.
+- `src/App.vue`
+  - Imports the sidebar layout and polls `/health` via `poll()` every 5 seconds, updating the `health` badge.
+  - Uses the router outlet to render view components.
+
+### Routing
+- `src/router/index.ts` enumerates routes for home, generator, settings, ST introduction steps, and security requirements pages. Each route maps to a view component exported from `src/views`.
+
+### Services
+- `src/services/api.ts`
+  - `resolveBaseURL()` checks Vite env vars, dev mode, and `window.location` to determine the REST base URL.
+  - Exports a configured Axios instance reused across views.
+- `src/services/sessionService.ts`
+  - `SessionService` class encapsulates localStorage persistence keyed by a generated user token (`getOrCreateUserToken()`).
+  - Exposes methods grouped by workflow segment:
+    - SFR: `saveSfrData()`, `loadSfrData()`, `clearSfrData()`, `clearAllSfrData()`, `hasSessionData()`.
+    - SAR: `saveSarData()`, `loadSarData()`, `clearSarData()`, `clearAllSarData()`.
+    - Cover: `saveCoverData()`, `loadCoverData()`, `clearCoverData()`.
+    - ST reference: `saveStReferenceData()`, `loadStReferenceData()`, `clearStReferenceData()`.
+    - TOE reference: `saveToeReferenceData()`, `loadToeReferenceData()`, `clearToeReferenceData()`.
+    - TOE overview: `saveToeOverviewData()`, `loadToeOverviewData()`, `clearToeOverviewData()`.
+    - TOE description: `saveToeDescriptionData()`, `loadToeDescriptionData()`, `clearToeDescriptionData()`.
+  - Helpers such as `getNamespacedKey()` maintain per-user storage isolation. The singleton export `sessionService` is reused across views.
+
+### Reusable Components
+- `src/components/Sidebar.vue` toggles accordion sections for ST Introduction and Security Requirements using `ref` booleans `stIntroOpen` and `securityOpen`.
+- `src/components/XMLTreeNode.vue`
+  - Accepts `node` + `level` props.
+  - `toggleExpanded()` collapses/expands children; `getNodeClass()` returns CSS classes based on XML node types.
+- `src/components/RichTextEditor.vue`
+  - Wraps TipTap editor configuration via `useEditor()`.
+  - Provides toolbar handlers (`toggleInline`, `applyHeading`, `applyList`, `applyHighlight`, `toggleSuperscript`, `toggleSubscript`, `setAlignment`, `insertImage`, `insertTable`, `handleTableAction`) that update the `editor` instance and emit `update:modelValue`.
+  - Watches the bound `modelValue` prop to keep external state and the editor instance synchronised and disposes of resources in `onBeforeUnmount`.
+
+### Views
+- `Home.vue` presents navigation CTAs only.
+- `Cover.vue`
+  - Manages file drag/drop via `handleDrop()`, `triggerFileDialog()`, and `handleFileSelection()`.
+  - Validates uploads with `validateImage()`, posts to `/cover/upload` through `uploadFile()`, and caches responses in `sessionService` (`saveSessionData()`, `loadSessionData()`).
+  - Preview handling uses `openPreview()`, `closePreview()`, and `renderPreview()` (after the API call in `generatePreview()`) to display DOCX content with `docx-preview`.
+  - Cleans up in `onBeforeUnmount` by calling backend cleanup endpoints.
+- `Generator.vue` contains placeholder text for the upcoming generator module.
+- `Settings.vue` wires to session storage and backend endpoints for listing/importing projects (see table actions such as `fetchProjects()` and modal toggles).
+- `SecurityFunctionalRequirements.vue`
+  - Provides CRUD-like operations for SFR lists: `fetchFamilies()`, `searchFamilies()`, `selectComponent()`, `addRequirement()`, `duplicateRequirement()`, `updateRequirement()`, `removeRequirement()`, `exportDocxPreview()`.
+  - Persists selections through the session service and triggers backend preview endpoints.
+- `SecurityAssuranceRequirements.vue`
+  - Similar session-driven workflows for SAR data: `fetchSarFamilies()`, `selectSarComponent()`, `addSarRequirement()`, `duplicateSarRequirement()`, `removeSarRequirement()`, `exportSarPreview()`.
+- `STReference.vue`, `TOEReference.vue`, `TOEOverview.vue`, `TOEDescription.vue`
+  - Each view uses the rich text editor to capture HTML, persists the data via the session service (`saveStReference()`, `saveToeReference()`, etc.), and posts to preview endpoints when requested.
+- `STIntroPreview.vue` aggregates stored cover/reference/TOE content, calls `/st-intro/preview`, and renders the returned DOCX using the shared preview pattern.
+
+### Types and Config
+- `src/env.d.ts` and `src/types/docx-preview.d.ts` provide TypeScript declarations for Vite env variables and the `docx-preview` renderer.
+- `vite.config.ts` sets up the Vue plugin and dev server proxy to `/api` (ensuring the Axios base URL strategy works during development).
+- `playwright.config.ts` specifies dev server launch commands for UI testing.
+
+### Tests
+- `tests/app.spec.ts` contains the baseline Playwright scenario verifying navigation between Home, Cover, Generator, and Settings routes.
+
+## Using Playwright for Web Verification
+1. Install dependencies: `npm install` (run inside `web/`).
+2. Ensure Playwright browsers are available: `npx playwright install --with-deps` (first run only).
+3. Start the FastAPI backend (see `server/AGENTS.md`) and launch the Vite dev server with `npm run dev -- --host`.
+4. Execute the existing suite or your new scenarios with `npm run test:e2e`. Use `npx playwright test --ui` for interactive debugging if needed.
+5. Capture screenshots via Playwright's tracing or `page.screenshot` helpers when diagnosing issues.
+
+Lastly, please test all your implementation, using your own tool like playwright, and take screenshot as your aid in debugging and for evidence.


### PR DESCRIPTION
## Summary
- add server-side AGENTS guide covering FastAPI modules, helpers, and testing expectations
- document Vue web module map, component responsibilities, and Playwright workflow

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5d279b240832684713dd4f7eb0a25