### PR TITLE
Enhance ST introduction editors and toolbar UX

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ccgentool2-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tiptap/extension-color": "^3.6.5",
         "@tiptap/extension-highlight": "3.6.5",
         "@tiptap/extension-image": "3.6.5",
         "@tiptap/extension-placeholder": "3.6.5",
@@ -20,13 +21,18 @@
         "@tiptap/extension-task-item": "3.6.5",
         "@tiptap/extension-task-list": "3.6.5",
         "@tiptap/extension-text-align": "3.6.5",
+        "@tiptap/extension-text-style": "^3.6.5",
         "@tiptap/extension-underline": "3.6.5",
         "@tiptap/pm": "3.6.5",
+        "@tiptap/react": "^3.6.5",
         "@tiptap/starter-kit": "3.6.5",
         "@tiptap/vue-3": "3.6.5",
         "axios": "1.7.7",
         "docx-preview": "^0.3.7",
         "pinia": "2.2.4",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "tiptap-extension-resizable-image": "^2.0.0",
         "vue": "3.4.38",
         "vue-router": "4.4.5",
         "vue3-easy-data-table": "^1.5.47"
@@ -869,6 +875,19 @@
         "@tiptap/pm": "^3.6.5"
       }
     },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.6.5.tgz",
+      "integrity": "sha512-6R14R0UdDjqomKy6S7gTfwxv1kSzELbiMxkqgMxQ7qfrN9HeNbyVTJjksBJcOQAO3LUevQm2C5YTJFlRmUX25Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.6.5"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.6.5.tgz",
@@ -1245,6 +1264,19 @@
         "@tiptap/core": "^3.6.5"
       }
     },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.6.5.tgz",
+      "integrity": "sha512-RsFomrmpVsf0/l+mvsfO99eg+KV0U/NyVl7rrWBRzBWQ6rOPYZbJrZwKNPRJHx5bfjw5qWmT8ey4J2EjysCzog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.5"
+      }
+    },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.6.5.tgz",
@@ -1300,6 +1332,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.6.5.tgz",
+      "integrity": "sha512-kum9fYzY6qmHuabcXDUTX2sVLdtJtZS0kN91mwD29Ue8HUkjVvEX92PwV2HtgNw3WFMaVxgm/dtm3XPTAlUEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-deep-equal": "^3.1.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.6.5",
+        "@tiptap/extension-floating-menu": "^3.6.5"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.5",
+        "@tiptap/pm": "^3.6.5",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tiptap/starter-kit": {
@@ -1384,6 +1443,32 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1693,6 +1778,12 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -1849,6 +1940,12 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -1884,6 +1981,18 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.19",
@@ -2316,6 +2425,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -2383,6 +2517,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -2406,11 +2549,32 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tiptap-extension-resizable-image": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tiptap-extension-resizable-image/-/tiptap-extension-resizable-image-2.0.0.tgz",
+      "integrity": "sha512-wIZY9m4xrusbCt5BKOx+V71cwGNSbFi/J+Xr0q94VFGS+MXPSWt0TdIQ4kCN4jQoXYICmL+A6ta89wVCYhnL+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tiptap/core": ">=2",
+        "@tiptap/pm": ">=2",
+        "@tiptap/react": ">=2",
+        "react": ">=18"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@tiptap/extension-color": "^3.6.5",
     "@tiptap/extension-highlight": "3.6.5",
     "@tiptap/extension-image": "3.6.5",
     "@tiptap/extension-placeholder": "3.6.5",
@@ -22,13 +23,18 @@
     "@tiptap/extension-task-item": "3.6.5",
     "@tiptap/extension-task-list": "3.6.5",
     "@tiptap/extension-text-align": "3.6.5",
+    "@tiptap/extension-text-style": "^3.6.5",
     "@tiptap/extension-underline": "3.6.5",
     "@tiptap/pm": "3.6.5",
+    "@tiptap/react": "^3.6.5",
     "@tiptap/starter-kit": "3.6.5",
     "@tiptap/vue-3": "3.6.5",
     "axios": "1.7.7",
     "docx-preview": "^0.3.7",
     "pinia": "2.2.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tiptap-extension-resizable-image": "^2.0.0",
     "vue": "3.4.38",
     "vue-router": "4.4.5",
     "vue3-easy-data-table": "^1.5.47"

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -2,17 +2,37 @@
   <div v-if="editor" class="rich-text-editor">
     <div class="toolbar">
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" :disabled="!editor.can().undo()" @click="editor.chain().focus().undo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          :disabled="!editor.can().undo()"
+          @click="editor.chain().focus().undo().run()"
+          title="Undo"
+          aria-label="Undo"
+        >
           ⟲
         </button>
-        <button type="button" class="toolbar-button" :disabled="!editor.can().redo()" @click="editor.chain().focus().redo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          :disabled="!editor.can().redo()"
+          @click="editor.chain().focus().redo().run()"
+          title="Redo"
+          aria-label="Redo"
+        >
           ⟳
         </button>
       </div>
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="heading-select">Text Size</label>
-        <select id="heading-select" class="toolbar-select" v-model="headingSelection" @change="applyHeading">
+        <select
+          id="heading-select"
+          class="toolbar-select"
+          v-model="headingSelection"
+          @change="applyHeading"
+          title="Change text size"
+        >
           <option value="paragraph">Paragraph</option>
           <option value="1">Heading 1</option>
           <option value="2">Heading 2</option>
@@ -23,7 +43,13 @@
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="list-select">Lists</label>
-        <select id="list-select" class="toolbar-select" v-model="listSelection" @change="applyList">
+        <select
+          id="list-select"
+          class="toolbar-select"
+          v-model="listSelection"
+          @change="applyList"
+          title="Insert list"
+        >
           <option value="">Select</option>
           <option value="bullet">Bullet list</option>
           <option value="ordered">Ordered list</option>
@@ -33,23 +59,57 @@
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('bold') }" @click="toggleInline('bold')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('bold') }"
+          @click="toggleInline('bold')"
+          title="Bold"
+          aria-label="Bold"
+        >
           B
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('italic') }" @click="toggleInline('italic')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('italic') }"
+          @click="toggleInline('italic')"
+          title="Italic"
+          aria-label="Italic"
+        >
           I
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('strike') }" @click="toggleInline('strike')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('strike') }"
+          @click="toggleInline('strike')"
+          title="Strikethrough"
+          aria-label="Strikethrough"
+        >
           S
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('underline') }" @click="toggleInline('underline')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('underline') }"
+          @click="toggleInline('underline')"
+          title="Underline"
+          aria-label="Underline"
+        >
           U
         </button>
       </div>
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="highlight-select">Highlight</label>
-        <select id="highlight-select" class="toolbar-select" v-model="highlightSelection" @change="applyHighlight">
+        <select
+          id="highlight-select"
+          class="toolbar-select"
+          v-model="highlightSelection"
+          @change="applyHighlight"
+          title="Apply highlight"
+        >
           <option value="">Select</option>
           <option value="green">Green</option>
           <option value="yellow">Yellow</option>
@@ -59,44 +119,120 @@
         </select>
       </div>
 
+      <div class="toolbar-group">
+        <label class="toolbar-label" for="text-color-select">Text Color</label>
+        <select
+          id="text-color-select"
+          class="toolbar-select"
+          v-model="textColorSelection"
+          @change="applyTextColor"
+          title="Change text color"
+        >
+          <option value="">Select</option>
+          <option value="red">Red</option>
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+          <option value="black">Black</option>
+        </select>
+      </div>
+
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('superscript') }" @click="toggleSuperscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('superscript') }"
+          @click="toggleSuperscript"
+          title="Superscript"
+          aria-label="Superscript"
+        >
           X<sup>2</sup>
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('subscript') }" @click="toggleSubscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('subscript') }"
+          @click="toggleSubscript"
+          title="Subscript"
+          aria-label="Subscript"
+        >
           X<sub>2</sub>
         </button>
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'left' }) }" @click="setAlignment('left')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'left' }) }"
+          @click="setAlignment('left')"
+          title="Align left"
+          aria-label="Align left"
+        >
           ⬅
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'center' }) }" @click="setAlignment('center')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'center' }) }"
+          @click="setAlignment('center')"
+          title="Align center"
+          aria-label="Align center"
+        >
           ⬍
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'right' }) }" @click="setAlignment('right')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'right' }) }"
+          @click="setAlignment('right')"
+          title="Align right"
+          aria-label="Align right"
+        >
           ➡
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'justify' }) }" @click="setAlignment('justify')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'justify' }) }"
+          @click="setAlignment('justify')"
+          title="Justify"
+          aria-label="Justify"
+        >
           ☰
         </button>
       </div>
 
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" @click="insertImage">🖼</button>
+        <button type="button" class="toolbar-button" @click="triggerImagePicker" title="Insert image" aria-label="Insert image">
+          🖼
+        </button>
+        <input
+          ref="imageInput"
+          class="file-input"
+          type="file"
+          accept="image/*"
+          @change="handleImageSelected"
+        />
       </div>
 
       <div class="toolbar-group table-group">
         <label class="toolbar-label">Insert Table</label>
         <div class="table-inputs">
-          <input type="number" min="1" v-model.number="tableRows" />
+          <input type="number" min="1" v-model.number="tableRows" title="Number of rows" />
           <span>×</span>
-          <input type="number" min="1" v-model.number="tableCols" />
-          <button type="button" class="toolbar-button" @click="insertTable">Insert</button>
+          <input type="number" min="1" v-model.number="tableCols" title="Number of columns" />
+          <button type="button" class="toolbar-button" @click="insertTable" title="Insert table" aria-label="Insert table">
+            Insert
+          </button>
         </div>
         <label class="toolbar-label" for="table-action-select">Delete</label>
-        <select id="table-action-select" class="toolbar-select" v-model="tableAction" @change="handleTableAction">
+        <select
+          id="table-action-select"
+          class="toolbar-select"
+          v-model="tableAction"
+          @change="handleTableAction"
+          title="Table actions"
+        >
           <option value="">Select</option>
           <option value="delete-row">Delete row</option>
           <option value="delete-column">Delete column</option>
@@ -116,7 +252,6 @@ import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Highlight from '@tiptap/extension-highlight'
 import TextAlign from '@tiptap/extension-text-align'
-import Image from '@tiptap/extension-image'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
@@ -126,6 +261,10 @@ import Subscript from '@tiptap/extension-subscript'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import Placeholder from '@tiptap/extension-placeholder'
+import { TextStyle } from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
+import { ResizableImage } from 'tiptap-extension-resizable-image'
+import 'tiptap-extension-resizable-image/styles.css'
 
 const props = withDefaults(
   defineProps<{
@@ -145,15 +284,24 @@ const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
 const headingSelection = ref<'paragraph' | '1' | '2' | '3' | '4'>('paragraph')
 const listSelection = ref('')
 const highlightSelection = ref('')
+const textColorSelection = ref('')
 const tableAction = ref('')
 const tableRows = ref(2)
 const tableCols = ref(2)
+const imageInput = ref<HTMLInputElement | null>(null)
 
 const highlightMap: Record<string, string> = {
   green: '#22c55e',
   yellow: '#facc15',
   blue: '#60a5fa',
   red: '#f87171',
+}
+
+const colorMap: Record<string, string> = {
+  red: '#ef4444',
+  blue: '#3b82f6',
+  green: '#22c55e',
+  black: '#111827',
 }
 
 const editor = useEditor({
@@ -167,7 +315,12 @@ const editor = useEditor({
     Underline,
     Highlight.configure({ multicolor: true }),
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
-    Image.configure({ inline: false, allowBase64: true }),
+    TextStyle,
+    Color,
+    ResizableImage.configure({
+      allowBase64: true,
+      inline: false,
+    }),
     Table.configure({ resizable: true }),
     TableRow,
     TableHeader,
@@ -269,6 +422,19 @@ function applyHighlight() {
   highlightSelection.value = ''
 }
 
+function applyTextColor() {
+  if (!editor?.value) return
+  const value = textColorSelection.value
+  const chain = editor.value.chain().focus()
+  if (value && value in colorMap) {
+    chain.setColor(colorMap[value]).run()
+  }
+  if (!value) {
+    chain.unsetColor().run()
+  }
+  textColorSelection.value = ''
+}
+
 function toggleSuperscript() {
   if (!editor?.value) return
   editor.value.chain().focus().toggleSuperscript().run()
@@ -284,11 +450,32 @@ function setAlignment(alignment: 'left' | 'center' | 'right' | 'justify') {
   editor.value.chain().focus().setTextAlign(alignment).run()
 }
 
-function insertImage() {
+function triggerImagePicker() {
+  imageInput.value?.click()
+}
+
+function handleImageSelected(event: Event) {
   if (!editor?.value) return
-  const url = window.prompt('Enter image URL')
-  if (!url) return
-  editor.value.chain().focus().setImage({ src: url }).run()
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    const result = reader.result
+    if (typeof result === 'string') {
+      editor.value?.chain().focus().setResizableImage({ src: result }).run()
+    }
+    if (imageInput.value) {
+      imageInput.value.value = ''
+    }
+  }
+  reader.onerror = () => {
+    if (imageInput.value) {
+      imageInput.value.value = ''
+    }
+  }
+  reader.readAsDataURL(file)
 }
 
 function insertTable() {
@@ -398,6 +585,17 @@ onBeforeUnmount(() => {
   color: #fff;
 }
 
+.file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .table-inputs {
   display: flex;
   align-items: center;
@@ -420,6 +618,14 @@ onBeforeUnmount(() => {
   background: rgba(15, 23, 42, 0.6);
   color: var(--text);
   line-height: 1.6;
+  position: relative;
+}
+
+.editor :deep(.ProseMirror) {
+  min-height: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  outline: none;
 }
 
 .editor :deep(p.is-editor-empty:first-child::before) {
@@ -433,6 +639,28 @@ onBeforeUnmount(() => {
 .editor :deep(table) {
   border-collapse: collapse;
   width: 100%;
+}
+
+.editor :deep(.selectedCell) {
+  position: relative;
+  box-shadow: inset 0 0 0 2px var(--primary);
+}
+
+.editor :deep(.selectedCell)::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border: 2px solid rgba(37, 99, 235, 0.5);
+  pointer-events: none;
+}
+
+.editor :deep(.ProseMirror-selectednode) {
+  outline: 2px solid rgba(37, 99, 235, 0.7);
+}
+
+.editor :deep(.resize-cursor),
+.editor :deep(.column-resize-handle) {
+  background-color: rgba(37, 99, 235, 0.65);
 }
 
 .editor :deep(th),

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -7,9 +7,6 @@
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
     </li>
     <li>
-      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -41,6 +38,10 @@
         </div>
       </div>
     </li>
+    <li class="menu-spacer" aria-hidden="true"></li>
+    <li class="settings-link">
+      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
+    </li>
   </ul>
 </template>
 
@@ -51,4 +52,17 @@ const securityOpen = ref(true)
 </script>
 
 <style scoped>
+.menu {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.menu-spacer {
+  flex: 1;
+}
+
+.settings-link {
+  margin-top: auto;
+}
 </style>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -60,6 +60,7 @@ export interface TOEOverviewSessionData {
 }
 
 export interface TOEDescriptionSessionData {
+  toeGeneralDescription: string
   toePhysicalScope: string
   toeLogicalScope: string
   userToken: string
@@ -521,6 +522,10 @@ class SessionService {
         console.warn('Session token mismatch, ignoring stored TOE Description data')
         return null
       }
+
+      sessionData.toeGeneralDescription = sessionData.toeGeneralDescription ?? ''
+      sessionData.toePhysicalScope = sessionData.toePhysicalScope ?? ''
+      sessionData.toeLogicalScope = sessionData.toeLogicalScope ?? ''
 
       return sessionData
     } catch (error) {

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -150,7 +150,7 @@ function hasTOEOverviewContent(data: TOEOverviewSessionData | null): boolean {
 
 function hasTOEDescriptionContent(data: TOEDescriptionSessionData | null): boolean {
   if (!data) return false
-  return Boolean(data.toePhysicalScope || data.toeLogicalScope)
+  return Boolean(data.toeGeneralDescription || data.toePhysicalScope || data.toeLogicalScope)
 }
 
 function updateSectionStatus() {
@@ -260,22 +260,28 @@ function buildTOEOverviewHTML(): string {
 
 function buildTOEDescriptionHTML(): string {
   const data = sessionService.loadTOEDescriptionData()
-  if (!data || (!data.toePhysicalScope && !data.toeLogicalScope)) {
+  if (!data || (!data.toeGeneralDescription && !data.toePhysicalScope && !data.toeLogicalScope)) {
     return ''
   }
 
   let html = ''
-  
+  let sectionIndex = 1
+
+  if (data.toeGeneralDescription) {
+    html += `<h4>1.4.${sectionIndex++} Target of Evaluation (TOE) Description</h4>`
+    html += `<div>${data.toeGeneralDescription}</div>`
+  }
+
   if (data.toePhysicalScope) {
-    html += '<h4>1.4.1 TOE Physical Scope</h4>'
+    html += `<h4>1.4.${sectionIndex++} TOE Physical Scope</h4>`
     html += `<div>${data.toePhysicalScope}</div>`
   }
-  
+
   if (data.toeLogicalScope) {
-    html += '<h4>1.4.2 TOE Logical Scope</h4>'
+    html += `<h4>1.4.${sectionIndex++} TOE Logical Scope</h4>`
     html += `<div>${data.toeLogicalScope}</div>`
   }
-  
+
   return html
 }
 

--- a/web/src/views/TOEDescription.vue
+++ b/web/src/views/TOEDescription.vue
@@ -10,6 +10,15 @@
     <div class="card toe-description-body">
       <form class="toe-description-form">
         <div class="form-section">
+          <h3>Target of Evaluation (TOE) Description:</h3>
+          <RichTextEditor
+            v-model="form.toeGeneralDescription"
+            placeholder="Enter overall TOE description"
+            min-height="260px"
+          />
+        </div>
+
+        <div class="form-section">
           <h3>TOE Physical Scope:</h3>
           <RichTextEditor
             v-model="form.toePhysicalScope"
@@ -37,12 +46,14 @@ import RichTextEditor from '../components/RichTextEditor.vue'
 import { sessionService } from '../services/sessionService'
 
 const form = reactive({
+  toeGeneralDescription: '',
   toePhysicalScope: '',
   toeLogicalScope: '',
 })
 
 function saveSessionData() {
   sessionService.saveTOEDescriptionData({
+    toeGeneralDescription: form.toeGeneralDescription,
     toePhysicalScope: form.toePhysicalScope,
     toeLogicalScope: form.toeLogicalScope,
   })
@@ -51,8 +62,9 @@ function saveSessionData() {
 function loadSessionData() {
   const data = sessionService.loadTOEDescriptionData()
   if (data) {
-    form.toePhysicalScope = data.toePhysicalScope
-    form.toeLogicalScope = data.toeLogicalScope
+    form.toeGeneralDescription = data.toeGeneralDescription || ''
+    form.toePhysicalScope = data.toePhysicalScope || ''
+    form.toeLogicalScope = data.toeLogicalScope || ''
   }
 }
 


### PR DESCRIPTION
## Summary
- move the settings link to the bottom of the sidebar for easier access
- upgrade the rich text editor with tooltips, text colour options, local image uploads with resizing, and clearer table resize cues
- add a general TOE description editor, persist it in session storage, and include it in the ST introduction preview output
- register additional TipTap extensions needed for the new toolbar features

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d9da105083269c85c8814346e920