### PR TITLE
Enhance ST intro editors and sidebar layout

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ccgentool2-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tiptap/extension-color": "^3.6.5",
         "@tiptap/extension-highlight": "3.6.5",
         "@tiptap/extension-image": "3.6.5",
         "@tiptap/extension-placeholder": "3.6.5",
@@ -20,13 +21,18 @@
         "@tiptap/extension-task-item": "3.6.5",
         "@tiptap/extension-task-list": "3.6.5",
         "@tiptap/extension-text-align": "3.6.5",
+        "@tiptap/extension-text-style": "^3.6.5",
         "@tiptap/extension-underline": "3.6.5",
         "@tiptap/pm": "3.6.5",
+        "@tiptap/react": "^3.6.5",
         "@tiptap/starter-kit": "3.6.5",
         "@tiptap/vue-3": "3.6.5",
         "axios": "1.7.7",
         "docx-preview": "^0.3.7",
         "pinia": "2.2.4",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "tiptap-extension-resizable-image": "^2.0.0",
         "vue": "3.4.38",
         "vue-router": "4.4.5",
         "vue3-easy-data-table": "^1.5.47"
@@ -869,6 +875,19 @@
         "@tiptap/pm": "^3.6.5"
       }
     },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.6.5.tgz",
+      "integrity": "sha512-6R14R0UdDjqomKy6S7gTfwxv1kSzELbiMxkqgMxQ7qfrN9HeNbyVTJjksBJcOQAO3LUevQm2C5YTJFlRmUX25Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.6.5"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.6.5.tgz",
@@ -1245,6 +1264,19 @@
         "@tiptap/core": "^3.6.5"
       }
     },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.6.5.tgz",
+      "integrity": "sha512-RsFomrmpVsf0/l+mvsfO99eg+KV0U/NyVl7rrWBRzBWQ6rOPYZbJrZwKNPRJHx5bfjw5qWmT8ey4J2EjysCzog==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.5"
+      }
+    },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.6.5.tgz",
@@ -1300,6 +1332,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.6.5.tgz",
+      "integrity": "sha512-kum9fYzY6qmHuabcXDUTX2sVLdtJtZS0kN91mwD29Ue8HUkjVvEX92PwV2HtgNw3WFMaVxgm/dtm3XPTAlUEwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-deep-equal": "^3.1.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.6.5",
+        "@tiptap/extension-floating-menu": "^3.6.5"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.5",
+        "@tiptap/pm": "^3.6.5",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@tiptap/starter-kit": {
@@ -1384,6 +1443,32 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1692,6 +1777,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -2316,6 +2407,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -2383,6 +2495,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -2406,11 +2524,32 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/tiptap-extension-resizable-image": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tiptap-extension-resizable-image/-/tiptap-extension-resizable-image-2.0.0.tgz",
+      "integrity": "sha512-wIZY9m4xrusbCt5BKOx+V71cwGNSbFi/J+Xr0q94VFGS+MXPSWt0TdIQ4kCN4jQoXYICmL+A6ta89wVCYhnL+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tiptap/core": ">=2",
+        "@tiptap/pm": ">=2",
+        "@tiptap/react": ">=2",
+        "react": ">=18"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@tiptap/extension-color": "^3.6.5",
     "@tiptap/extension-highlight": "3.6.5",
     "@tiptap/extension-image": "3.6.5",
     "@tiptap/extension-placeholder": "3.6.5",
@@ -22,13 +23,18 @@
     "@tiptap/extension-task-item": "3.6.5",
     "@tiptap/extension-task-list": "3.6.5",
     "@tiptap/extension-text-align": "3.6.5",
+    "@tiptap/extension-text-style": "^3.6.5",
     "@tiptap/extension-underline": "3.6.5",
     "@tiptap/pm": "3.6.5",
+    "@tiptap/react": "^3.6.5",
     "@tiptap/starter-kit": "3.6.5",
     "@tiptap/vue-3": "3.6.5",
     "axios": "1.7.7",
     "docx-preview": "^0.3.7",
     "pinia": "2.2.4",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "tiptap-extension-resizable-image": "^2.0.0",
     "vue": "3.4.38",
     "vue-router": "4.4.5",
     "vue3-easy-data-table": "^1.5.47"

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -2,10 +2,22 @@
   <div v-if="editor" class="rich-text-editor">
     <div class="toolbar">
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" :disabled="!editor.can().undo()" @click="editor.chain().focus().undo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Undo"
+          :disabled="!editor.can().undo()"
+          @click="editor.chain().focus().undo().run()"
+        >
           ⟲
         </button>
-        <button type="button" class="toolbar-button" :disabled="!editor.can().redo()" @click="editor.chain().focus().redo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Redo"
+          :disabled="!editor.can().redo()"
+          @click="editor.chain().focus().redo().run()"
+        >
           ⟳
         </button>
       </div>
@@ -33,16 +45,40 @@
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('bold') }" @click="toggleInline('bold')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Bold"
+          :class="{ active: editor.isActive('bold') }"
+          @click="toggleInline('bold')"
+        >
           B
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('italic') }" @click="toggleInline('italic')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Italic"
+          :class="{ active: editor.isActive('italic') }"
+          @click="toggleInline('italic')"
+        >
           I
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('strike') }" @click="toggleInline('strike')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Strikethrough"
+          :class="{ active: editor.isActive('strike') }"
+          @click="toggleInline('strike')"
+        >
           S
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('underline') }" @click="toggleInline('underline')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Underline"
+          :class="{ active: editor.isActive('underline') }"
+          @click="toggleInline('underline')"
+        >
           U
         </button>
       </div>
@@ -59,32 +95,79 @@
         </select>
       </div>
 
+      <div class="toolbar-group">
+        <label class="toolbar-label" for="color-select">Text Color</label>
+        <select id="color-select" class="toolbar-select" v-model="colorSelection" @change="applyTextColor">
+          <option value="default">Default</option>
+          <option value="red">Red</option>
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+          <option value="black">Black</option>
+        </select>
+      </div>
+
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('superscript') }" @click="toggleSuperscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Superscript"
+          :class="{ active: editor.isActive('superscript') }"
+          @click="toggleSuperscript"
+        >
           X<sup>2</sup>
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('subscript') }" @click="toggleSubscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Subscript"
+          :class="{ active: editor.isActive('subscript') }"
+          @click="toggleSubscript"
+        >
           X<sub>2</sub>
         </button>
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'left' }) }" @click="setAlignment('left')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Align left"
+          :class="{ active: editor.isActive({ textAlign: 'left' }) }"
+          @click="setAlignment('left')"
+        >
           ⬅
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'center' }) }" @click="setAlignment('center')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Align center"
+          :class="{ active: editor.isActive({ textAlign: 'center' }) }"
+          @click="setAlignment('center')"
+        >
           ⬍
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'right' }) }" @click="setAlignment('right')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Align right"
+          :class="{ active: editor.isActive({ textAlign: 'right' }) }"
+          @click="setAlignment('right')"
+        >
           ➡
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'justify' }) }" @click="setAlignment('justify')">
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Justify"
+          :class="{ active: editor.isActive({ textAlign: 'justify' }) }"
+          @click="setAlignment('justify')"
+        >
           ☰
         </button>
       </div>
 
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" @click="insertImage">🖼</button>
+        <button type="button" class="toolbar-button" title="Insert image" @click="triggerImageUpload">🖼</button>
       </div>
 
       <div class="toolbar-group table-group">
@@ -93,7 +176,7 @@
           <input type="number" min="1" v-model.number="tableRows" />
           <span>×</span>
           <input type="number" min="1" v-model.number="tableCols" />
-          <button type="button" class="toolbar-button" @click="insertTable">Insert</button>
+          <button type="button" class="toolbar-button" title="Insert table" @click="insertTable">Insert</button>
         </div>
         <label class="toolbar-label" for="table-action-select">Delete</label>
         <select id="table-action-select" class="toolbar-select" v-model="tableAction" @change="handleTableAction">
@@ -103,7 +186,15 @@
           <option value="delete-table">Delete table</option>
         </select>
       </div>
-    </div>
+      </div>
+
+    <input
+      ref="imageInputRef"
+      type="file"
+      class="hidden-file-input"
+      accept="image/*"
+      @change="handleImageSelection"
+    />
 
     <EditorContent :editor="editor" class="editor" :style="{ minHeight: minHeight }" />
   </div>
@@ -116,7 +207,8 @@ import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Highlight from '@tiptap/extension-highlight'
 import TextAlign from '@tiptap/extension-text-align'
-import Image from '@tiptap/extension-image'
+import { TextStyle } from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
@@ -126,6 +218,8 @@ import Subscript from '@tiptap/extension-subscript'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import Placeholder from '@tiptap/extension-placeholder'
+import { ResizableImage } from 'tiptap-extension-resizable-image'
+import 'tiptap-extension-resizable-image/styles.css'
 
 const props = withDefaults(
   defineProps<{
@@ -145,15 +239,24 @@ const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
 const headingSelection = ref<'paragraph' | '1' | '2' | '3' | '4'>('paragraph')
 const listSelection = ref('')
 const highlightSelection = ref('')
+const colorSelection = ref<'default' | 'red' | 'blue' | 'green' | 'black'>('default')
 const tableAction = ref('')
 const tableRows = ref(2)
 const tableCols = ref(2)
+const imageInputRef = ref<HTMLInputElement | null>(null)
 
 const highlightMap: Record<string, string> = {
   green: '#22c55e',
   yellow: '#facc15',
   blue: '#60a5fa',
   red: '#f87171',
+}
+
+const textColorMap: Record<'red' | 'blue' | 'green' | 'black', string> = {
+  red: '#ef4444',
+  blue: '#3b82f6',
+  green: '#22c55e',
+  black: '#0f172a',
 }
 
 const editor = useEditor({
@@ -167,7 +270,9 @@ const editor = useEditor({
     Underline,
     Highlight.configure({ multicolor: true }),
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
-    Image.configure({ inline: false, allowBase64: true }),
+    TextStyle,
+    Color.configure({ types: ['textStyle'] }),
+    ResizableImage.configure({ allowBase64: true, defaultWidth: 500, defaultHeight: 300 }),
     Table.configure({ resizable: true }),
     TableRow,
     TableHeader,
@@ -195,6 +300,16 @@ function updateToolbarState() {
   else if (instance.isActive('heading', { level: 3 })) headingSelection.value = '3'
   else if (instance.isActive('heading', { level: 4 })) headingSelection.value = '4'
   else headingSelection.value = 'paragraph'
+
+  const currentColor = instance.getAttributes('textStyle')?.color?.toLowerCase?.()
+  if (currentColor) {
+    const match = (Object.entries(textColorMap) as [typeof colorSelection.value, string][]).find(
+      ([, value]) => value.toLowerCase() === currentColor
+    )
+    colorSelection.value = match ? match[0] : 'default'
+  } else {
+    colorSelection.value = 'default'
+  }
 }
 
 watch(
@@ -269,6 +384,17 @@ function applyHighlight() {
   highlightSelection.value = ''
 }
 
+function applyTextColor() {
+  if (!editor?.value) return
+  const value = colorSelection.value
+  const chain = editor.value.chain().focus()
+  if (value === 'default') {
+    chain.unsetColor().run()
+  } else {
+    chain.setColor(textColorMap[value]).run()
+  }
+}
+
 function toggleSuperscript() {
   if (!editor?.value) return
   editor.value.chain().focus().toggleSuperscript().run()
@@ -284,11 +410,29 @@ function setAlignment(alignment: 'left' | 'center' | 'right' | 'justify') {
   editor.value.chain().focus().setTextAlign(alignment).run()
 }
 
-function insertImage() {
+function triggerImageUpload() {
+  imageInputRef.value?.click()
+}
+
+function handleImageSelection(event: Event) {
   if (!editor?.value) return
-  const url = window.prompt('Enter image URL')
-  if (!url) return
-  editor.value.chain().focus().setImage({ src: url }).run()
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    const result = reader.result
+    if (typeof result === 'string') {
+      editor.value
+        ?.chain()
+        .focus()
+        .setResizableImage({ src: result, alt: file.name, 'data-keep-ratio': true })
+        .run()
+    }
+  }
+  reader.readAsDataURL(file)
+  input.value = ''
 }
 
 function insertTable() {
@@ -413,6 +557,10 @@ onBeforeUnmount(() => {
   padding: 4px 6px;
 }
 
+.hidden-file-input {
+  display: none;
+}
+
 .editor {
   border: 1px solid #374151;
   border-radius: 12px;
@@ -420,6 +568,11 @@ onBeforeUnmount(() => {
   background: rgba(15, 23, 42, 0.6);
   color: var(--text);
   line-height: 1.6;
+  cursor: text;
+}
+
+.editor :deep(.ProseMirror) {
+  min-height: 100%;
 }
 
 .editor :deep(p.is-editor-empty:first-child::before) {
@@ -435,10 +588,33 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
+.editor :deep(.tableWrapper) {
+  position: relative;
+}
+
+.editor :deep(.tableWrapper:hover),
+.editor :deep(.tableWrapper.is-resizing) {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
 .editor :deep(th),
 .editor :deep(td) {
   border: 1px solid #4b5563;
   padding: 6px 10px;
+}
+
+.editor :deep(.selectedCell) {
+  background: rgba(59, 130, 246, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.5);
+}
+
+.editor :deep(.column-resize-handle) {
+  position: absolute;
+  right: -2px;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: rgba(59, 130, 246, 0.5);
 }
 
 .editor :deep(ul),

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -7,9 +7,6 @@
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
     </li>
     <li>
-      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -41,6 +38,10 @@
         </div>
       </div>
     </li>
+    <li class="menu-spacer" aria-hidden="true"></li>
+    <li class="menu-settings">
+      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
+    </li>
   </ul>
 </template>
 
@@ -51,4 +52,17 @@ const securityOpen = ref(true)
 </script>
 
 <style scoped>
+.menu {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.menu-spacer {
+  flex: 1 1 auto;
+}
+
+.menu-settings {
+  margin-top: auto;
+}
 </style>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -60,6 +60,7 @@ export interface TOEOverviewSessionData {
 }
 
 export interface TOEDescriptionSessionData {
+  toeGeneralDescription: string
   toePhysicalScope: string
   toeLogicalScope: string
   userToken: string

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -150,7 +150,7 @@ function hasTOEOverviewContent(data: TOEOverviewSessionData | null): boolean {
 
 function hasTOEDescriptionContent(data: TOEDescriptionSessionData | null): boolean {
   if (!data) return false
-  return Boolean(data.toePhysicalScope || data.toeLogicalScope)
+  return Boolean(data.toeGeneralDescription || data.toePhysicalScope || data.toeLogicalScope)
 }
 
 function updateSectionStatus() {
@@ -260,22 +260,27 @@ function buildTOEOverviewHTML(): string {
 
 function buildTOEDescriptionHTML(): string {
   const data = sessionService.loadTOEDescriptionData()
-  if (!data || (!data.toePhysicalScope && !data.toeLogicalScope)) {
+  if (!data || (!data.toeGeneralDescription && !data.toePhysicalScope && !data.toeLogicalScope)) {
     return ''
   }
 
   let html = ''
-  
+
+  if (data.toeGeneralDescription) {
+    html += '<h4>1.4.0 TOE Description Overview</h4>'
+    html += `<div>${data.toeGeneralDescription}</div>`
+  }
+
   if (data.toePhysicalScope) {
     html += '<h4>1.4.1 TOE Physical Scope</h4>'
     html += `<div>${data.toePhysicalScope}</div>`
   }
-  
+
   if (data.toeLogicalScope) {
     html += '<h4>1.4.2 TOE Logical Scope</h4>'
     html += `<div>${data.toeLogicalScope}</div>`
   }
-  
+
   return html
 }
 

--- a/web/src/views/TOEDescription.vue
+++ b/web/src/views/TOEDescription.vue
@@ -10,6 +10,15 @@
     <div class="card toe-description-body">
       <form class="toe-description-form">
         <div class="form-section">
+          <h3>Target of Evaluation (TOE) Description:</h3>
+          <RichTextEditor
+            v-model="form.toeGeneralDescription"
+            placeholder="Enter general TOE description"
+            min-height="260px"
+          />
+        </div>
+
+        <div class="form-section">
           <h3>TOE Physical Scope:</h3>
           <RichTextEditor
             v-model="form.toePhysicalScope"
@@ -37,12 +46,14 @@ import RichTextEditor from '../components/RichTextEditor.vue'
 import { sessionService } from '../services/sessionService'
 
 const form = reactive({
+  toeGeneralDescription: '',
   toePhysicalScope: '',
   toeLogicalScope: '',
 })
 
 function saveSessionData() {
   sessionService.saveTOEDescriptionData({
+    toeGeneralDescription: form.toeGeneralDescription,
     toePhysicalScope: form.toePhysicalScope,
     toeLogicalScope: form.toeLogicalScope,
   })
@@ -51,8 +62,9 @@ function saveSessionData() {
 function loadSessionData() {
   const data = sessionService.loadTOEDescriptionData()
   if (data) {
-    form.toePhysicalScope = data.toePhysicalScope
-    form.toeLogicalScope = data.toeLogicalScope
+    form.toeGeneralDescription = data.toeGeneralDescription ?? ''
+    form.toePhysicalScope = data.toePhysicalScope ?? ''
+    form.toeLogicalScope = data.toeLogicalScope ?? ''
   }
 }
 


### PR DESCRIPTION
## Summary
- move the Settings navigation link to the bottom of the sidebar so it stays pinned beneath the ST sections
- upgrade the TipTap editor toolbar with tooltips, text color selection, image uploads with resizable images, and clearer table resizing feedback
- add a general TOE description field to the TOE Description step and include it in session storage and the ST introduction preview payload

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d9da105083269c85c8814346e920