### PR TITLE
Improve TipTap editor ergonomics and TOE description flow

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "axios": "1.7.7",
         "docx-preview": "^0.3.7",
         "pinia": "2.2.4",
+        "tiptap-extension-resize-image": "^1.3.1",
         "vue": "3.4.38",
         "vue-router": "4.4.5",
         "vue3-easy-data-table": "^1.5.47"
@@ -2432,6 +2433,17 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tiptap-extension-resize-image": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiptap-extension-resize-image/-/tiptap-extension-resize-image-1.3.1.tgz",
+      "integrity": "sha512-z3ihACUJFDzU3agORWT8CXG+jJYOoIl84jR+77qKjlH6w16xZjZpmDG2kUb9sxAcEX9GDhF/m7eFnPyGHzmlmg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0 || ^3.0.0",
+        "@tiptap/extension-image": "^2.0.0 || ^3.0.0",
+        "@tiptap/pm": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/uc.micro": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ccgentool2-web",
       "version": "0.1.0",
       "dependencies": {
+        "@tiptap/extension-color": "3.6.5",
         "@tiptap/extension-highlight": "3.6.5",
         "@tiptap/extension-image": "3.6.5",
         "@tiptap/extension-placeholder": "3.6.5",
@@ -20,6 +21,7 @@
         "@tiptap/extension-task-item": "3.6.5",
         "@tiptap/extension-task-list": "3.6.5",
         "@tiptap/extension-text-align": "3.6.5",
+        "@tiptap/extension-text-style": "3.6.5",
         "@tiptap/extension-underline": "3.6.5",
         "@tiptap/pm": "3.6.5",
         "@tiptap/starter-kit": "3.6.5",
@@ -869,6 +871,19 @@
         "@tiptap/pm": "^3.6.5"
       }
     },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.6.5.tgz",
+      "integrity": "sha512-6R14R0UdDjqomKy6S7gTfwxv1kSzELbiMxkqgMxQ7qfrN9HeNbyVTJjksBJcOQAO3LUevQm2C5YTJFlRmUX25Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.6.5"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.6.5.tgz",
@@ -1236,6 +1251,19 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.6.5.tgz",
       "integrity": "sha512-QdFHQqRKbuUnBDoQkW3yYrUUFvYIlvZJPMH65+egicPiVOOFxB8zRlQI/FCpCRH97w+zFbpEXrFxvXgB7K2Vxg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.6.5"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.6.5.tgz",
+      "integrity": "sha512-RsFomrmpVsf0/l+mvsfO99eg+KV0U/NyVl7rrWBRzBWQ6rOPYZbJrZwKNPRJHx5bfjw5qWmT8ey4J2EjysCzog==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,8 @@
     "@tiptap/extension-table-row": "3.6.5",
     "@tiptap/extension-task-item": "3.6.5",
     "@tiptap/extension-task-list": "3.6.5",
+    "@tiptap/extension-text-style": "3.6.5",
+    "@tiptap/extension-color": "3.6.5",
     "@tiptap/extension-text-align": "3.6.5",
     "@tiptap/extension-underline": "3.6.5",
     "@tiptap/pm": "3.6.5",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@tiptap/extension-color": "3.6.5",
     "@tiptap/extension-highlight": "3.6.5",
     "@tiptap/extension-image": "3.6.5",
     "@tiptap/extension-placeholder": "3.6.5",
@@ -21,9 +22,8 @@
     "@tiptap/extension-table-row": "3.6.5",
     "@tiptap/extension-task-item": "3.6.5",
     "@tiptap/extension-task-list": "3.6.5",
-    "@tiptap/extension-text-style": "3.6.5",
-    "@tiptap/extension-color": "3.6.5",
     "@tiptap/extension-text-align": "3.6.5",
+    "@tiptap/extension-text-style": "3.6.5",
     "@tiptap/extension-underline": "3.6.5",
     "@tiptap/pm": "3.6.5",
     "@tiptap/starter-kit": "3.6.5",
@@ -31,6 +31,7 @@
     "axios": "1.7.7",
     "docx-preview": "^0.3.7",
     "pinia": "2.2.4",
+    "tiptap-extension-resize-image": "^1.3.1",
     "vue": "3.4.38",
     "vue-router": "4.4.5",
     "vue3-easy-data-table": "^1.5.47"

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -2,17 +2,38 @@
   <div v-if="editor" class="rich-text-editor">
     <div class="toolbar">
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" :disabled="!editor.can().undo()" @click="editor.chain().focus().undo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          :disabled="!editor.can().undo()"
+          title="Undo"
+          aria-label="Undo"
+          @click="editor.chain().focus().undo().run()"
+        >
           ⟲
         </button>
-        <button type="button" class="toolbar-button" :disabled="!editor.can().redo()" @click="editor.chain().focus().redo().run()">
+        <button
+          type="button"
+          class="toolbar-button"
+          :disabled="!editor.can().redo()"
+          title="Redo"
+          aria-label="Redo"
+          @click="editor.chain().focus().redo().run()"
+        >
           ⟳
         </button>
       </div>
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="heading-select">Text Size</label>
-        <select id="heading-select" class="toolbar-select" v-model="headingSelection" @change="applyHeading">
+        <select
+          id="heading-select"
+          class="toolbar-select"
+          v-model="headingSelection"
+          title="Change text size"
+          aria-label="Change text size"
+          @change="applyHeading"
+        >
           <option value="paragraph">Paragraph</option>
           <option value="1">Heading 1</option>
           <option value="2">Heading 2</option>
@@ -23,7 +44,14 @@
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="list-select">Lists</label>
-        <select id="list-select" class="toolbar-select" v-model="listSelection" @change="applyList">
+        <select
+          id="list-select"
+          class="toolbar-select"
+          v-model="listSelection"
+          title="Insert or remove list"
+          aria-label="Insert or remove list"
+          @change="applyList"
+        >
           <option value="">Select</option>
           <option value="bullet">Bullet list</option>
           <option value="ordered">Ordered list</option>
@@ -32,24 +60,77 @@
         </select>
       </div>
 
+      <div class="toolbar-group">
+        <label class="toolbar-label" for="color-select">Text Color</label>
+        <select
+          id="color-select"
+          class="toolbar-select"
+          v-model="colorSelection"
+          title="Change text color"
+          aria-label="Change text color"
+          @change="applyColor"
+        >
+          <option value="default">Default</option>
+          <option value="black">Black</option>
+          <option value="red">Red</option>
+          <option value="blue">Blue</option>
+          <option value="green">Green</option>
+        </select>
+      </div>
+
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('bold') }" @click="toggleInline('bold')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('bold') }"
+          title="Bold"
+          aria-label="Bold"
+          @click="toggleInline('bold')"
+        >
           B
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('italic') }" @click="toggleInline('italic')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('italic') }"
+          title="Italic"
+          aria-label="Italic"
+          @click="toggleInline('italic')"
+        >
           I
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('strike') }" @click="toggleInline('strike')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('strike') }"
+          title="Strikethrough"
+          aria-label="Strikethrough"
+          @click="toggleInline('strike')"
+        >
           S
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('underline') }" @click="toggleInline('underline')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('underline') }"
+          title="Underline"
+          aria-label="Underline"
+          @click="toggleInline('underline')"
+        >
           U
         </button>
       </div>
 
       <div class="toolbar-group">
         <label class="toolbar-label" for="highlight-select">Highlight</label>
-        <select id="highlight-select" class="toolbar-select" v-model="highlightSelection" @change="applyHighlight">
+        <select
+          id="highlight-select"
+          class="toolbar-select"
+          v-model="highlightSelection"
+          title="Highlight text"
+          aria-label="Highlight text"
+          @change="applyHighlight"
+        >
           <option value="">Select</option>
           <option value="green">Green</option>
           <option value="yellow">Yellow</option>
@@ -60,43 +141,130 @@
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('superscript') }" @click="toggleSuperscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('superscript') }"
+          title="Superscript"
+          aria-label="Superscript"
+          @click="toggleSuperscript"
+        >
           X<sup>2</sup>
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive('subscript') }" @click="toggleSubscript">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive('subscript') }"
+          title="Subscript"
+          aria-label="Subscript"
+          @click="toggleSubscript"
+        >
           X<sub>2</sub>
         </button>
       </div>
 
       <div class="toolbar-group format-group">
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'left' }) }" @click="setAlignment('left')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'left' }) }"
+          title="Align left"
+          aria-label="Align left"
+          @click="setAlignment('left')"
+        >
           ⬅
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'center' }) }" @click="setAlignment('center')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'center' }) }"
+          title="Align center"
+          aria-label="Align center"
+          @click="setAlignment('center')"
+        >
           ⬍
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'right' }) }" @click="setAlignment('right')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'right' }) }"
+          title="Align right"
+          aria-label="Align right"
+          @click="setAlignment('right')"
+        >
           ➡
         </button>
-        <button type="button" class="toolbar-button" :class="{ active: editor.isActive({ textAlign: 'justify' }) }" @click="setAlignment('justify')">
+        <button
+          type="button"
+          class="toolbar-button"
+          :class="{ active: editor.isActive({ textAlign: 'justify' }) }"
+          title="Justify"
+          aria-label="Justify"
+          @click="setAlignment('justify')"
+        >
           ☰
         </button>
       </div>
 
       <div class="toolbar-group">
-        <button type="button" class="toolbar-button" @click="insertImage">🖼</button>
+        <button
+          type="button"
+          class="toolbar-button"
+          title="Insert image"
+          aria-label="Insert image"
+          @click="triggerImageUpload"
+        >
+          🖼
+        </button>
+        <input
+          ref="imageInput"
+          type="file"
+          accept="image/*"
+          class="sr-only"
+          aria-hidden="true"
+          @change="handleImageSelection"
+        />
       </div>
 
       <div class="toolbar-group table-group">
-        <label class="toolbar-label">Insert Table</label>
+        <label class="toolbar-label" for="table-rows">Insert Table</label>
         <div class="table-inputs">
-          <input type="number" min="1" v-model.number="tableRows" />
-          <span>×</span>
-          <input type="number" min="1" v-model.number="tableCols" />
-          <button type="button" class="toolbar-button" @click="insertTable">Insert</button>
+          <input
+            id="table-rows"
+            type="number"
+            min="1"
+            v-model.number="tableRows"
+            title="Number of rows"
+            aria-label="Number of rows"
+          />
+          <span aria-hidden="true">×</span>
+          <input
+            id="table-columns"
+            type="number"
+            min="1"
+            v-model.number="tableCols"
+            title="Number of columns"
+            aria-label="Number of columns"
+          />
+          <button
+            type="button"
+            class="toolbar-button"
+            title="Insert table"
+            aria-label="Insert table"
+            @click="insertTable"
+          >
+            Insert
+          </button>
         </div>
         <label class="toolbar-label" for="table-action-select">Delete</label>
-        <select id="table-action-select" class="toolbar-select" v-model="tableAction" @change="handleTableAction">
+        <select
+          id="table-action-select"
+          class="toolbar-select"
+          v-model="tableAction"
+          title="Delete table elements"
+          aria-label="Delete table elements"
+          @change="handleTableAction"
+        >
           <option value="">Select</option>
           <option value="delete-row">Delete row</option>
           <option value="delete-column">Delete column</option>
@@ -105,7 +273,12 @@
       </div>
     </div>
 
-    <EditorContent :editor="editor" class="editor" :style="{ minHeight: minHeight }" />
+    <EditorContent
+      :editor="editor"
+      class="editor"
+      :style="{ minHeight: minHeight }"
+      aria-label="Rich text editor"
+    />
   </div>
 </template>
 
@@ -126,6 +299,8 @@ import Subscript from '@tiptap/extension-subscript'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import Placeholder from '@tiptap/extension-placeholder'
+import { TextStyle } from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
 
 const props = withDefaults(
   defineProps<{
@@ -142,18 +317,30 @@ const props = withDefaults(
 
 const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
 
-const headingSelection = ref<'paragraph' | '1' | '2' | '3' | '4'>('paragraph')
+type HeadingSelection = 'paragraph' | '1' | '2' | '3' | '4'
+type ColorOption = 'default' | 'black' | 'red' | 'blue' | 'green'
+
+const headingSelection = ref<HeadingSelection>('paragraph')
 const listSelection = ref('')
 const highlightSelection = ref('')
 const tableAction = ref('')
 const tableRows = ref(2)
 const tableCols = ref(2)
+const colorSelection = ref<ColorOption>('default')
+const imageInput = ref<HTMLInputElement | null>(null)
 
 const highlightMap: Record<string, string> = {
   green: '#22c55e',
   yellow: '#facc15',
   blue: '#60a5fa',
   red: '#f87171',
+}
+
+const colorMap: Record<Exclude<ColorOption, 'default'>, string> = {
+  black: '#000000',
+  red: '#ef4444',
+  blue: '#3b82f6',
+  green: '#22c55e',
 }
 
 const editor = useEditor({
@@ -166,6 +353,8 @@ const editor = useEditor({
     }),
     Underline,
     Highlight.configure({ multicolor: true }),
+    TextStyle,
+    Color.configure({ types: ['textStyle'] }),
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
     Image.configure({ inline: false, allowBase64: true }),
     Table.configure({ resizable: true }),
@@ -195,6 +384,13 @@ function updateToolbarState() {
   else if (instance.isActive('heading', { level: 3 })) headingSelection.value = '3'
   else if (instance.isActive('heading', { level: 4 })) headingSelection.value = '4'
   else headingSelection.value = 'paragraph'
+
+  const textStyleAttrs = instance.getAttributes('textStyle') as { color?: string }
+  const activeColor = typeof textStyleAttrs?.color === 'string' ? textStyleAttrs.color.toLowerCase() : ''
+  const colorEntry = (Object.entries(colorMap) as [Exclude<ColorOption, 'default'>, string][]).find(
+    ([, value]) => value === activeColor
+  )
+  colorSelection.value = colorEntry ? colorEntry[0] : 'default'
 }
 
 watch(
@@ -216,6 +412,7 @@ function applyHeading() {
   } else {
     chain.setHeading({ level: Number(level) as 1 | 2 | 3 | 4 }).run()
   }
+  updateToolbarState()
 }
 
 function applyList() {
@@ -236,6 +433,7 @@ function applyList() {
       break
   }
   listSelection.value = ''
+  updateToolbarState()
 }
 
 function toggleInline(type: 'bold' | 'italic' | 'strike' | 'underline') {
@@ -255,6 +453,7 @@ function toggleInline(type: 'bold' | 'italic' | 'strike' | 'underline') {
       chain.toggleUnderline().run()
       break
   }
+  updateToolbarState()
 }
 
 function applyHighlight() {
@@ -267,28 +466,71 @@ function applyHighlight() {
     chain.setHighlight({ color: highlightMap[value] }).run()
   }
   highlightSelection.value = ''
+  updateToolbarState()
 }
 
 function toggleSuperscript() {
   if (!editor?.value) return
   editor.value.chain().focus().toggleSuperscript().run()
+  updateToolbarState()
 }
 
 function toggleSubscript() {
   if (!editor?.value) return
   editor.value.chain().focus().toggleSubscript().run()
+  updateToolbarState()
 }
 
 function setAlignment(alignment: 'left' | 'center' | 'right' | 'justify') {
   if (!editor?.value) return
   editor.value.chain().focus().setTextAlign(alignment).run()
+  updateToolbarState()
 }
 
-function insertImage() {
+function applyColor() {
   if (!editor?.value) return
-  const url = window.prompt('Enter image URL')
-  if (!url) return
-  editor.value.chain().focus().setImage({ src: url }).run()
+  const selection = colorSelection.value
+  const chain = editor.value.chain().focus()
+  if (selection === 'default') {
+    chain.unsetColor().run()
+  } else {
+    chain.setColor(colorMap[selection]).run()
+  }
+  updateToolbarState()
+}
+
+function triggerImageUpload() {
+  imageInput.value?.click()
+}
+
+function handleImageSelection(event: Event) {
+  if (!editor?.value) return
+  const target = event.target as HTMLInputElement | null
+  const file = target?.files?.[0]
+
+  if (!file) {
+    if (target) target.value = ''
+    return
+  }
+
+  const reader = new FileReader()
+  reader.onload = () => {
+    const result = reader.result
+    if (typeof result === 'string') {
+      editor.value?.chain().focus().setImage({ src: result }).run()
+      updateToolbarState()
+    }
+    if (target) {
+      target.value = ''
+    }
+  }
+  reader.onerror = () => {
+    console.error('Failed to read the selected image file.')
+    if (target) {
+      target.value = ''
+    }
+  }
+  reader.readAsDataURL(file)
 }
 
 function insertTable() {
@@ -296,6 +538,7 @@ function insertTable() {
   const rows = Math.max(1, tableRows.value || 1)
   const cols = Math.max(1, tableCols.value || 1)
   editor.value.chain().focus().insertTable({ rows, cols, withHeaderRow: true }).run()
+  updateToolbarState()
 }
 
 function handleTableAction() {
@@ -313,6 +556,7 @@ function handleTableAction() {
       break
   }
   tableAction.value = ''
+  updateToolbarState()
 }
 
 onBeforeUnmount(() => {
@@ -398,6 +642,18 @@ onBeforeUnmount(() => {
   color: #fff;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .table-inputs {
   display: flex;
   align-items: center;
@@ -420,6 +676,8 @@ onBeforeUnmount(() => {
   background: rgba(15, 23, 42, 0.6);
   color: var(--text);
   line-height: 1.6;
+  width: 100%;
+  cursor: text;
 }
 
 .editor :deep(p.is-editor-empty:first-child::before) {
@@ -430,15 +688,84 @@ onBeforeUnmount(() => {
   pointer-events: none;
 }
 
+.editor :deep(.ProseMirror) {
+  min-height: inherit;
+  outline: none;
+}
+
 .editor :deep(table) {
   border-collapse: collapse;
   width: 100%;
+  table-layout: fixed;
 }
 
 .editor :deep(th),
 .editor :deep(td) {
   border: 1px solid #4b5563;
   padding: 6px 10px;
+  position: relative;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  cursor: text;
+}
+
+.editor :deep(th:hover),
+.editor :deep(td:hover) {
+  border-color: rgba(59, 130, 246, 0.7);
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+.editor :deep(th:hover)::after,
+.editor :deep(td:hover)::after {
+  content: '';
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid rgba(59, 130, 246, 0.8);
+  border-bottom: 2px solid rgba(59, 130, 246, 0.8);
+  pointer-events: none;
+}
+
+.editor :deep(.selectedCell) {
+  border-color: rgba(59, 130, 246, 0.9);
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.4);
+}
+
+.editor :deep(.tableWrapper) {
+  position: relative;
+  overflow-x: auto;
+}
+
+.editor :deep(.tableWrapper:hover .column-resize-handle),
+.editor :deep(.tableWrapper:hover .row-resize-handle) {
+  opacity: 1;
+}
+
+.editor :deep(.column-resize-handle),
+.editor :deep(.row-resize-handle) {
+  position: absolute;
+  background: rgba(59, 130, 246, 0.6);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.editor :deep(.column-resize-handle) {
+  cursor: col-resize;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  right: -3px;
+}
+
+.editor :deep(.row-resize-handle) {
+  cursor: row-resize;
+  left: 0;
+  right: 0;
+  height: 6px;
+  bottom: -3px;
 }
 
 .editor :deep(ul),

--- a/web/src/components/RichTextEditor.vue
+++ b/web/src/components/RichTextEditor.vue
@@ -289,7 +289,7 @@ import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import Highlight from '@tiptap/extension-highlight'
 import TextAlign from '@tiptap/extension-text-align'
-import Image from '@tiptap/extension-image'
+import ImageResize from 'tiptap-extension-resize-image'
 import { Table } from '@tiptap/extension-table'
 import TableRow from '@tiptap/extension-table-row'
 import TableHeader from '@tiptap/extension-table-header'
@@ -356,7 +356,7 @@ const editor = useEditor({
     TextStyle,
     Color.configure({ types: ['textStyle'] }),
     TextAlign.configure({ types: ['heading', 'paragraph'] }),
-    Image.configure({ inline: false, allowBase64: true }),
+    ImageResize.configure({ inline: false, allowBase64: true }),
     Table.configure({ resizable: true }),
     TableRow,
     TableHeader,
@@ -678,6 +678,16 @@ onBeforeUnmount(() => {
   line-height: 1.6;
   width: 100%;
   cursor: text;
+}
+
+.editor :deep(img) {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.editor :deep([style*='cursor: pointer;']) {
+  max-width: 100%;
 }
 
 .editor :deep(p.is-editor-empty:first-child::before) {

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -7,9 +7,6 @@
       <RouterLink to="/generator" active-class="active">Generator</RouterLink>
     </li>
     <li>
-      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -40,6 +37,9 @@
           </ul>
         </div>
       </div>
+    </li>
+    <li>
+      <RouterLink to="/settings" active-class="active">Settings</RouterLink>
     </li>
   </ul>
 </template>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -60,6 +60,7 @@ export interface TOEOverviewSessionData {
 }
 
 export interface TOEDescriptionSessionData {
+  toeDescription: string
   toePhysicalScope: string
   toeLogicalScope: string
   userToken: string
@@ -521,6 +522,10 @@ class SessionService {
         console.warn('Session token mismatch, ignoring stored TOE Description data')
         return null
       }
+
+      sessionData.toeDescription = sessionData.toeDescription || ''
+      sessionData.toePhysicalScope = sessionData.toePhysicalScope || ''
+      sessionData.toeLogicalScope = sessionData.toeLogicalScope || ''
 
       return sessionData
     } catch (error) {

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -150,7 +150,7 @@ function hasTOEOverviewContent(data: TOEOverviewSessionData | null): boolean {
 
 function hasTOEDescriptionContent(data: TOEDescriptionSessionData | null): boolean {
   if (!data) return false
-  return Boolean(data.toePhysicalScope || data.toeLogicalScope)
+  return Boolean(data.toeDescription || data.toePhysicalScope || data.toeLogicalScope)
 }
 
 function updateSectionStatus() {
@@ -260,22 +260,26 @@ function buildTOEOverviewHTML(): string {
 
 function buildTOEDescriptionHTML(): string {
   const data = sessionService.loadTOEDescriptionData()
-  if (!data || (!data.toePhysicalScope && !data.toeLogicalScope)) {
+  if (!data || (!data.toeDescription && !data.toePhysicalScope && !data.toeLogicalScope)) {
     return ''
   }
 
   let html = ''
-  
+
+  if (data.toeDescription) {
+    html += `<div>${data.toeDescription}</div>`
+  }
+
   if (data.toePhysicalScope) {
     html += '<h4>1.4.1 TOE Physical Scope</h4>'
     html += `<div>${data.toePhysicalScope}</div>`
   }
-  
+
   if (data.toeLogicalScope) {
     html += '<h4>1.4.2 TOE Logical Scope</h4>'
     html += `<div>${data.toeLogicalScope}</div>`
   }
-  
+
   return html
 }
 

--- a/web/src/views/TOEDescription.vue
+++ b/web/src/views/TOEDescription.vue
@@ -10,6 +10,15 @@
     <div class="card toe-description-body">
       <form class="toe-description-form">
         <div class="form-section">
+          <h3>TOE Description:</h3>
+          <RichTextEditor
+            v-model="form.toeDescription"
+            placeholder="Enter the Target of Evaluation description"
+            min-height="260px"
+          />
+        </div>
+
+        <div class="form-section">
           <h3>TOE Physical Scope:</h3>
           <RichTextEditor
             v-model="form.toePhysicalScope"
@@ -37,12 +46,14 @@ import RichTextEditor from '../components/RichTextEditor.vue'
 import { sessionService } from '../services/sessionService'
 
 const form = reactive({
+  toeDescription: '',
   toePhysicalScope: '',
   toeLogicalScope: '',
 })
 
 function saveSessionData() {
   sessionService.saveTOEDescriptionData({
+    toeDescription: form.toeDescription,
     toePhysicalScope: form.toePhysicalScope,
     toeLogicalScope: form.toeLogicalScope,
   })
@@ -51,8 +62,9 @@ function saveSessionData() {
 function loadSessionData() {
   const data = sessionService.loadTOEDescriptionData()
   if (data) {
-    form.toePhysicalScope = data.toePhysicalScope
-    form.toeLogicalScope = data.toeLogicalScope
+    form.toeDescription = data.toeDescription || ''
+    form.toePhysicalScope = data.toePhysicalScope || ''
+    form.toeLogicalScope = data.toeLogicalScope || ''
   }
 }
 


### PR DESCRIPTION
## Summary
- move the Settings link to the bottom of the sidebar navigation
- expand the TipTap editor with tooltips, colour picker, image uploads, and clearer table resizing cues
- add a dedicated TOE Description editor, persist the value, and include it in the ST introduction preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5e20397088326b3f9ab568759b6cc