### PR TITLE
Support base64 cover images and restructure final preview

### DIFF
--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,9 +4,6 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/generator" active-class="active">Generator</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -25,6 +22,9 @@
       </div>
     </li>
     <li>
+      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
+    </li>
+    <li>
       <div class="accordion">
         <div class="accordion-header" @click="securityOpen = !securityOpen">
           <span>Security Requirements</span>
@@ -37,9 +37,6 @@
           </ul>
         </div>
       </div>
-    </li>
-    <li>
-      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
     </li>
     <li>
       <RouterLink to="/final-preview" active-class="active">Final Document Preview</RouterLink>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -27,6 +27,7 @@ export interface CoverSessionData {
     date: string
   }
   uploadedImagePath: string | null
+  uploadedImageData: string | null
   userToken: string
   timestamp: number
 }
@@ -309,10 +310,11 @@ class SessionService {
   /**
    * Save Cover data to session storage
    */
-  saveCoverData(form: any, uploadedImagePath: string | null): void {
+  saveCoverData(form: any, uploadedImagePath: string | null, uploadedImageData: string | null): void {
     const sessionData: CoverSessionData = {
       form,
       uploadedImagePath,
+      uploadedImageData,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -337,7 +339,21 @@ class SessionService {
         return null
       }
 
-      const sessionData: CoverSessionData = JSON.parse(data)
+      const parsed = JSON.parse(data)
+      const sessionData: CoverSessionData = {
+        form: parsed.form || {
+          title: '',
+          version: '',
+          revision: '',
+          description: '',
+          manufacturer: '',
+          date: '',
+        },
+        uploadedImagePath: parsed.uploadedImagePath ?? null,
+        uploadedImageData: parsed.uploadedImageData ?? null,
+        userToken: parsed.userToken,
+        timestamp: parsed.timestamp,
+      }
 
       if (sessionData.userToken !== this.userToken) {
         console.warn('Session token mismatch, ignoring stored Cover data')

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -87,7 +87,11 @@ function loadProject(event: Event) {
 
       // Load all data back into session storage
       if (projectData.coverData) {
-        sessionService.saveCoverData(projectData.coverData.form, projectData.coverData.uploadedImagePath)
+        sessionService.saveCoverData(
+          projectData.coverData.form,
+          projectData.coverData.uploadedImagePath ?? null,
+          projectData.coverData.uploadedImageData ?? null
+        )
       }
       if (projectData.stReferenceData) {
         sessionService.saveSTReferenceData({

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -118,6 +118,7 @@ function hasCoverContent(data: CoverSessionData | null): boolean {
   const form = data.form || {}
   return Boolean(
     data.uploadedImagePath ||
+    data.uploadedImageData ||
     form.title ||
     form.version ||
     form.revision ||
@@ -323,6 +324,7 @@ async function generatePreview() {
             manufacturer: coverData.form.manufacturer,
             date: coverData.form.date,
             image_path: coverData.uploadedImagePath,
+            image_data: coverData.uploadedImageData,
           }
         : null,
       st_reference_html: stReferenceHTML || null,


### PR DESCRIPTION
## Summary
- persist cover uploads with their base64 payloads so previews and saved projects can reload images across devices
- update ST introduction and final preview document builders to embed cover base64 data, add the required introductory text, and organize sections with the new layout and download endpoint
- refresh the UI navigation and final preview download button to match the requested structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e608a52e2483269634a6f59b6926d1