### PR TITLE
Handle cover image persistence and restructure final preview

### DIFF
--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,9 +4,6 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/generator" active-class="active">Generator</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -25,6 +22,9 @@
       </div>
     </li>
     <li>
+      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
+    </li>
+    <li>
       <div class="accordion">
         <div class="accordion-header" @click="securityOpen = !securityOpen">
           <span>Security Requirements</span>
@@ -37,9 +37,6 @@
           </ul>
         </div>
       </div>
-    </li>
-    <li>
-      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
     </li>
     <li>
       <RouterLink to="/final-preview" active-class="active">Final Document Preview</RouterLink>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -27,6 +27,7 @@ export interface CoverSessionData {
     date: string
   }
   uploadedImagePath: string | null
+  imageBase64: string | null
   userToken: string
   timestamp: number
 }
@@ -309,10 +310,11 @@ class SessionService {
   /**
    * Save Cover data to session storage
    */
-  saveCoverData(form: any, uploadedImagePath: string | null): void {
+  saveCoverData(form: any, uploadedImagePath: string | null, imageBase64: string | null): void {
     const sessionData: CoverSessionData = {
       form,
       uploadedImagePath,
+      imageBase64,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -337,7 +339,10 @@ class SessionService {
         return null
       }
 
-      const sessionData: CoverSessionData = JSON.parse(data)
+      const sessionData: CoverSessionData = {
+        imageBase64: null,
+        ...JSON.parse(data),
+      }
 
       if (sessionData.userToken !== this.userToken) {
         console.warn('Session token mismatch, ignoring stored Cover data')

--- a/web/src/views/FinalDocumentPreview.vue
+++ b/web/src/views/FinalDocumentPreview.vue
@@ -22,14 +22,14 @@
         >
           {{ previewLoading ? 'Generating…' : 'Generate Preview' }}
         </button>
-        <a
+        <button
           v-if="generatedDocxPath && !previewLoading && !previewError"
-          :href="downloadUrl"
-          download="Security_Target_Document.docx"
           class="btn primary"
+          type="button"
+          @click="downloadDocx"
         >
           Download DOCX
-        </a>
+        </button>
       </div>
     </div>
 
@@ -143,6 +143,7 @@ function hasCoverContent(data: CoverSessionData | null): boolean {
   if (!data) return false
   const form = data.form || {}
   return Boolean(
+    data.imageBase64 ||
     data.uploadedImagePath ||
     form.title ||
     form.version ||
@@ -399,6 +400,7 @@ async function generatePreview() {
             manufacturer: coverData.form.manufacturer,
             date: coverData.form.date,
             image_path: coverData.uploadedImagePath,
+            image_base64: coverData.imageBase64,
           }
         : null,
       st_reference_html: stReferenceHTML || null,
@@ -488,8 +490,20 @@ const cleanupDocx = (keepalive = false) => {
   hasGeneratedDocx.value = false
 }
 
-const handleBeforeUnload = () => cleanupDocx(true)
-const handlePageHide = () => cleanupDocx(true)
+function downloadDocx() {
+  if (!downloadUrl.value) {
+    return
+  }
+
+  const link = document.createElement('a')
+  link.href = downloadUrl.value
+  link.target = '_blank'
+  link.rel = 'noopener'
+  link.download = 'Security_Target_Document.docx'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
 
 const handleWindowFocus = () => updateSectionStatus()
 
@@ -497,8 +511,6 @@ const addPreviewListeners = () => {
   if (typeof window === 'undefined') {
     return
   }
-  window.addEventListener('beforeunload', handleBeforeUnload)
-  window.addEventListener('pagehide', handlePageHide)
   window.addEventListener('focus', handleWindowFocus)
 }
 
@@ -506,8 +518,6 @@ const removePreviewListeners = () => {
   if (typeof window === 'undefined') {
     return
   }
-  window.removeEventListener('beforeunload', handleBeforeUnload)
-  window.removeEventListener('pagehide', handlePageHide)
   window.removeEventListener('focus', handleWindowFocus)
 }
 

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -87,7 +87,11 @@ function loadProject(event: Event) {
 
       // Load all data back into session storage
       if (projectData.coverData) {
-        sessionService.saveCoverData(projectData.coverData.form, projectData.coverData.uploadedImagePath)
+        sessionService.saveCoverData(
+          projectData.coverData.form,
+          projectData.coverData.uploadedImagePath ?? null,
+          projectData.coverData.imageBase64 ?? null,
+        )
       }
       if (projectData.stReferenceData) {
         sessionService.saveSTReferenceData({

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -117,6 +117,7 @@ function hasCoverContent(data: CoverSessionData | null): boolean {
   if (!data) return false
   const form = data.form || {}
   return Boolean(
+    data.imageBase64 ||
     data.uploadedImagePath ||
     form.title ||
     form.version ||
@@ -323,6 +324,7 @@ async function generatePreview() {
             manufacturer: coverData.form.manufacturer,
             date: coverData.form.date,
             image_path: coverData.uploadedImagePath,
+            image_base64: coverData.imageBase64,
           }
         : null,
       st_reference_html: stReferenceHTML || null,

--- a/web/tests/app.spec.ts
+++ b/web/tests/app.spec.ts
@@ -13,9 +13,13 @@ test.describe('CCGenTool navigation', () => {
     await expect(page.getByRole('heading', { name: 'Cover Image' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Preview Cover' })).toBeDisabled()
 
-    await page.getByRole('link', { name: 'Generator' }).first().click()
-    await expect(page.getByRole('heading', { name: 'Security Target Generator' })).toBeVisible()
-    await expect(page.getByText('Under Construction 🚧')).toBeVisible()
+    await page.getByRole('link', { name: 'Conformance Claims' }).click()
+    await expect(page.getByRole('heading', { level: 1, name: 'Conformance Claims' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Security Functional Requirements' }).click()
+    await expect(
+      page.getByRole('heading', { level: 2, name: 'Security Functional Requirements' }),
+    ).toBeVisible()
 
     await page.getByRole('link', { name: 'Settings' }).first().click()
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()


### PR DESCRIPTION
## Summary
- persist cover images as base64 across the Vue session service and reuse the data when uploading, previewing, or importing saved projects
- update the FastAPI backend and document builders to accept base64 images, inject the ST introduction preface, and group conformance/security sections with the requested page breaks
- reorder the sidebar navigation, ensure final preview downloads open in a new tab, and refresh the Playwright smoke test for the new navigation flow

## Testing
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e608a52e2483269634a6f59b6926d1