### PR TITLE
Support base64 cover images and fix final preview layout

### DIFF
--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,9 +4,6 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/generator" active-class="active">Generator</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -25,6 +22,9 @@
       </div>
     </li>
     <li>
+      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
+    </li>
+    <li>
       <div class="accordion">
         <div class="accordion-header" @click="securityOpen = !securityOpen">
           <span>Security Requirements</span>
@@ -37,9 +37,6 @@
           </ul>
         </div>
       </div>
-    </li>
-    <li>
-      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
     </li>
     <li>
       <RouterLink to="/final-preview" active-class="active">Final Document Preview</RouterLink>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -4,6 +4,7 @@ export interface SessionData {
   sfrList: any[]
   selectedSfrId: number | null
   nextSfrId: number
+  previewHtml?: string
   userToken: string
   timestamp: number
 }
@@ -13,6 +14,7 @@ export interface SarSessionData {
   selectedSarId: number | null
   nextSarId: number
   selectedEal?: string
+  previewHtml?: string
   userToken: string
   timestamp: number
 }
@@ -27,6 +29,7 @@ export interface CoverSessionData {
     date: string
   }
   uploadedImagePath: string | null
+  imageBase64: string | null
   userToken: string
   timestamp: number
 }
@@ -120,11 +123,17 @@ class SessionService {
   /**
    * Save SFR data to session storage
    */
-  saveSfrData(sfrList: any[], selectedSfrId: number | null, nextSfrId: number): void {
+  saveSfrData(
+    sfrList: any[],
+    selectedSfrId: number | null,
+    nextSfrId: number,
+    previewHtml: string = ''
+  ): void {
     const sessionData: SessionData = {
       sfrList,
       selectedSfrId,
       nextSfrId,
+      previewHtml,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -150,6 +159,9 @@ class SessionService {
       }
 
       const sessionData: SessionData = JSON.parse(data)
+      if (typeof sessionData.previewHtml !== 'string') {
+        sessionData.previewHtml = ''
+      }
 
       // Validate that the token matches
       if (sessionData.userToken !== this.userToken) {
@@ -194,12 +206,19 @@ class SessionService {
   /**
    * Save SAR data to session storage
    */
-  saveSarData(sarList: any[], selectedSarId: number | null, nextSarId: number, selectedEal: string): void {
+  saveSarData(
+    sarList: any[],
+    selectedSarId: number | null,
+    nextSarId: number,
+    selectedEal: string,
+    previewHtml: string = ''
+  ): void {
     const sessionData: SarSessionData = {
       sarList,
       selectedSarId,
       nextSarId,
       selectedEal,
+      previewHtml,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -225,6 +244,9 @@ class SessionService {
       }
 
       const sessionData: SarSessionData = JSON.parse(data)
+      if (typeof sessionData.previewHtml !== 'string') {
+        sessionData.previewHtml = ''
+      }
 
       if (sessionData.userToken !== this.userToken) {
         console.warn('Session token mismatch, ignoring stored SAR data')
@@ -309,10 +331,11 @@ class SessionService {
   /**
    * Save Cover data to session storage
    */
-  saveCoverData(form: any, uploadedImagePath: string | null): void {
+  saveCoverData(form: any, uploadedImagePath: string | null, imageBase64: string | null): void {
     const sessionData: CoverSessionData = {
       form,
       uploadedImagePath,
+      imageBase64,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -338,6 +361,10 @@ class SessionService {
       }
 
       const sessionData: CoverSessionData = JSON.parse(data)
+
+      if (typeof sessionData.imageBase64 !== 'string') {
+        sessionData.imageBase64 = sessionData.imageBase64 ? String(sessionData.imageBase64) : null
+      }
 
       if (sessionData.userToken !== this.userToken) {
         console.warn('Session token mismatch, ignoring stored Cover data')

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -87,7 +87,11 @@ function loadProject(event: Event) {
 
       // Load all data back into session storage
       if (projectData.coverData) {
-        sessionService.saveCoverData(projectData.coverData.form, projectData.coverData.uploadedImagePath)
+        sessionService.saveCoverData(
+          projectData.coverData.form,
+          projectData.coverData.uploadedImagePath,
+          projectData.coverData.imageBase64 || null
+        )
       }
       if (projectData.stReferenceData) {
         sessionService.saveSTReferenceData({
@@ -132,7 +136,8 @@ function loadProject(event: Event) {
         sessionService.saveSfrData(
           projectData.sfrData.sfrList,
           projectData.sfrData.selectedSfrId,
-          projectData.sfrData.nextSfrId
+          projectData.sfrData.nextSfrId,
+          projectData.sfrData.previewHtml || ''
         )
       }
       if (projectData.sarData) {
@@ -140,7 +145,8 @@ function loadProject(event: Event) {
           projectData.sarData.sarList,
           projectData.sarData.selectedSarId,
           projectData.sarData.nextSarId,
-          projectData.sarData.selectedEal
+          projectData.sarData.selectedEal,
+          projectData.sarData.previewHtml || ''
         )
       }
 

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -118,6 +118,7 @@ function hasCoverContent(data: CoverSessionData | null): boolean {
   const form = data.form || {}
   return Boolean(
     data.uploadedImagePath ||
+    data.imageBase64 ||
     form.title ||
     form.version ||
     form.revision ||
@@ -323,6 +324,7 @@ async function generatePreview() {
             manufacturer: coverData.form.manufacturer,
             date: coverData.form.date,
             image_path: coverData.uploadedImagePath,
+            image_base64: coverData.imageBase64,
           }
         : null,
       st_reference_html: stReferenceHTML || null,

--- a/web/src/views/SecurityAssuranceRequirements.vue
+++ b/web/src/views/SecurityAssuranceRequirements.vue
@@ -1097,7 +1097,13 @@ const saveSessionData = () => {
   if (isRestoringSession) {
     return
   }
-  sessionService.saveSarData(sarList.value, selectedSarId.value, nextSarId.value, selectedEal.value)
+  sessionService.saveSarData(
+    sarList.value,
+    selectedSarId.value,
+    nextSarId.value,
+    selectedEal.value,
+    selectedSarPreview.value
+  )
 }
 
 const deriveClassCodeForEntry = (entry: Partial<SarEntry> & { source?: SarSource }) => {

--- a/web/src/views/SecurityFunctionalRequirements.vue
+++ b/web/src/views/SecurityFunctionalRequirements.vue
@@ -979,7 +979,12 @@ const closePreviewModal = () => {
 }
 
 const saveSessionData = () => {
-  sessionService.saveSfrData(sfrList.value, selectedSfrId.value, nextSfrId.value)
+  sessionService.saveSfrData(
+    sfrList.value,
+    selectedSfrId.value,
+    nextSfrId.value,
+    selectedSfrPreview.value
+  )
 }
 
 const deriveClassCodeForEntry = (entry: Partial<SfrEntry> & { source?: SfrSource }) => {


### PR DESCRIPTION
## Summary
- ensure cover previews accept embedded base64 imagery and reuse it when downloading final documents
- reorganize the final document builder to follow the requested section order and surface SFR/SAR content with numbering
- expose a stable download endpoint and adjust the sidebar, session storage, and previews to match the updated flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e612f729e483268939e7de15a8b3d2