### PR TITLE
Handle embedded cover images and refine final document preview

### DIFF
--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -4,9 +4,6 @@
       <RouterLink to="/" active-class="active">Home</RouterLink>
     </li>
     <li>
-      <RouterLink to="/generator" active-class="active">Generator</RouterLink>
-    </li>
-    <li>
       <div class="accordion">
         <div class="accordion-header" @click="stIntroOpen = !stIntroOpen">
           <span>ST Introduction</span>
@@ -25,6 +22,9 @@
       </div>
     </li>
     <li>
+      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
+    </li>
+    <li>
       <div class="accordion">
         <div class="accordion-header" @click="securityOpen = !securityOpen">
           <span>Security Requirements</span>
@@ -37,9 +37,6 @@
           </ul>
         </div>
       </div>
-    </li>
-    <li>
-      <RouterLink to="/conformanceclaims" active-class="active">Conformance Claims</RouterLink>
     </li>
     <li>
       <RouterLink to="/final-preview" active-class="active">Final Document Preview</RouterLink>

--- a/web/src/services/sessionService.ts
+++ b/web/src/services/sessionService.ts
@@ -27,6 +27,7 @@ export interface CoverSessionData {
     date: string
   }
   uploadedImagePath: string | null
+  uploadedImageData: string | null
   userToken: string
   timestamp: number
 }
@@ -309,10 +310,11 @@ class SessionService {
   /**
    * Save Cover data to session storage
    */
-  saveCoverData(form: any, uploadedImagePath: string | null): void {
+  saveCoverData(form: any, uploadedImagePath: string | null, uploadedImageData: string | null): void {
     const sessionData: CoverSessionData = {
       form,
       uploadedImagePath,
+      uploadedImageData,
       userToken: this.userToken,
       timestamp: Date.now()
     }
@@ -337,11 +339,26 @@ class SessionService {
         return null
       }
 
-      const sessionData: CoverSessionData = JSON.parse(data)
+      const parsed = JSON.parse(data) as Partial<CoverSessionData>
 
-      if (sessionData.userToken !== this.userToken) {
+      if (parsed.userToken !== this.userToken) {
         console.warn('Session token mismatch, ignoring stored Cover data')
         return null
+      }
+
+      const sessionData: CoverSessionData = {
+        form: parsed.form ?? {
+          title: '',
+          version: '',
+          revision: '',
+          description: '',
+          manufacturer: '',
+          date: '',
+        },
+        uploadedImagePath: parsed.uploadedImagePath ?? null,
+        uploadedImageData: parsed.uploadedImageData ?? null,
+        userToken: parsed.userToken ?? this.userToken,
+        timestamp: parsed.timestamp ?? Date.now(),
       }
 
       return sessionData

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -87,7 +87,11 @@ function loadProject(event: Event) {
 
       // Load all data back into session storage
       if (projectData.coverData) {
-        sessionService.saveCoverData(projectData.coverData.form, projectData.coverData.uploadedImagePath)
+        sessionService.saveCoverData(
+          projectData.coverData.form,
+          projectData.coverData.uploadedImagePath,
+          projectData.coverData.uploadedImageData ?? null
+        )
       }
       if (projectData.stReferenceData) {
         sessionService.saveSTReferenceData({

--- a/web/src/views/STIntroPreview.vue
+++ b/web/src/views/STIntroPreview.vue
@@ -117,6 +117,7 @@ function hasCoverContent(data: CoverSessionData | null): boolean {
   if (!data) return false
   const form = data.form || {}
   return Boolean(
+    data.uploadedImageData ||
     data.uploadedImagePath ||
     form.title ||
     form.version ||
@@ -323,6 +324,7 @@ async function generatePreview() {
             manufacturer: coverData.form.manufacturer,
             date: coverData.form.date,
             image_path: coverData.uploadedImagePath,
+            image_data: coverData.uploadedImageData,
           }
         : null,
       st_reference_html: stReferenceHTML || null,

--- a/web/tests/app.spec.ts
+++ b/web/tests/app.spec.ts
@@ -13,9 +13,11 @@ test.describe('CCGenTool navigation', () => {
     await expect(page.getByRole('heading', { name: 'Cover Image' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Preview Cover' })).toBeDisabled()
 
-    await page.getByRole('link', { name: 'Generator' }).first().click()
-    await expect(page.getByRole('heading', { name: 'Security Target Generator' })).toBeVisible()
-    await expect(page.getByText('Under Construction 🚧')).toBeVisible()
+    await page.getByRole('link', { name: 'Conformance Claims' }).first().click()
+    await expect(page.getByRole('heading', { name: 'Conformance Claims', level: 1 })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Security Functional Requirements' }).first().click()
+    await expect(page.getByRole('heading', { name: 'Security Functional Requirements', level: 2 })).toBeVisible()
 
     await page.getByRole('link', { name: 'Settings' }).first().click()
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()


### PR DESCRIPTION
## Summary
- persist cover images as base64 so previews and exports work across sessions and devices
- restructure the final document builder to include the missing introduction copy and SFR/SAR content while fixing the download flow
- update the sidebar/navigation hierarchy and Playwright smoke test to match the revised IA

## Testing
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e612f729e483268939e7de15a8b3d2